### PR TITLE
feat: export packageVersion variable

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -144,6 +144,8 @@ async function generate() {
     .map((f) => `'${f.name}': ${f.componentName}`)
     .join(',')}}`
 
+  const versionExport = `/**\n * @public\n */\nexport const packageVersion = '${process.env.npm_package_version}'`
+
   const indexPath = path.resolve(SRC_ICONS_PATH, `index.ts`)
 
   const indexTsCode = await format(
@@ -156,6 +158,7 @@ async function generate() {
       iconExports,
       iconMapInterface,
       iconsExport,
+      versionExport,
     ].join('\n\n'),
     {
       ...prettierConfig,


### PR DESCRIPTION
`src/index.ts` now exports a `packageVersion` variable. This is happens when a new version is built.

#### Output:
```ts
/**
 * @public
 */
export const packageVersion = '2.9.0'
```

#### Reasoning:
We use a CDN for icons on our website, and a React component that wraps this logic. 
It would be nice to keep `@sanity/icons` in sync with this component in terms of types. This feature helps with that.