### PR TITLE
fix: add displayName to aid debugging

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -31,7 +31,8 @@ export const __NAME__ = forwardRef(function __NAME__(
   return (
     __JSX__
   )
-})
+});
+__NAME__.displayName = 'ForwardRef(__NAME__)'
 `
 
 async function readIcon(filePath: string) {

--- a/src/icon.tsx
+++ b/src/icon.tsx
@@ -25,3 +25,4 @@ export const Icon = forwardRef(function Icon(
 
   return <IconComponent {...restProps} ref={ref} />
 })
+Icon.displayName = 'ForwardRef(Icon)'

--- a/src/icons/accessDeniedIcon.tsx
+++ b/src/icons/accessDeniedIcon.tsx
@@ -29,3 +29,4 @@ export const AccessDeniedIcon = forwardRef(function AccessDeniedIcon(
     </svg>
   )
 })
+AccessDeniedIcon.displayName = 'ForwardRef(AccessDeniedIcon)'

--- a/src/icons/activityIcon.tsx
+++ b/src/icons/activityIcon.tsx
@@ -29,3 +29,4 @@ export const ActivityIcon = forwardRef(function ActivityIcon(
     </svg>
   )
 })
+ActivityIcon.displayName = 'ForwardRef(ActivityIcon)'

--- a/src/icons/addCircleIcon.tsx
+++ b/src/icons/addCircleIcon.tsx
@@ -29,3 +29,4 @@ export const AddCircleIcon = forwardRef(function AddCircleIcon(
     </svg>
   )
 })
+AddCircleIcon.displayName = 'ForwardRef(AddCircleIcon)'

--- a/src/icons/addCommentIcon.tsx
+++ b/src/icons/addCommentIcon.tsx
@@ -29,3 +29,4 @@ export const AddCommentIcon = forwardRef(function AddCommentIcon(
     </svg>
   )
 })
+AddCommentIcon.displayName = 'ForwardRef(AddCommentIcon)'

--- a/src/icons/addDocumentIcon.tsx
+++ b/src/icons/addDocumentIcon.tsx
@@ -30,3 +30,4 @@ export const AddDocumentIcon = forwardRef(function AddDocumentIcon(
     </svg>
   )
 })
+AddDocumentIcon.displayName = 'ForwardRef(AddDocumentIcon)'

--- a/src/icons/addIcon.tsx
+++ b/src/icons/addIcon.tsx
@@ -29,3 +29,4 @@ export const AddIcon = forwardRef(function AddIcon(
     </svg>
   )
 })
+AddIcon.displayName = 'ForwardRef(AddIcon)'

--- a/src/icons/apiIcon.tsx
+++ b/src/icons/apiIcon.tsx
@@ -35,3 +35,4 @@ export const ApiIcon = forwardRef(function ApiIcon(
     </svg>
   )
 })
+ApiIcon.displayName = 'ForwardRef(ApiIcon)'

--- a/src/icons/archiveIcon.tsx
+++ b/src/icons/archiveIcon.tsx
@@ -35,3 +35,4 @@ export const ArchiveIcon = forwardRef(function ArchiveIcon(
     </svg>
   )
 })
+ArchiveIcon.displayName = 'ForwardRef(ArchiveIcon)'

--- a/src/icons/arrowDownIcon.tsx
+++ b/src/icons/arrowDownIcon.tsx
@@ -30,3 +30,4 @@ export const ArrowDownIcon = forwardRef(function ArrowDownIcon(
     </svg>
   )
 })
+ArrowDownIcon.displayName = 'ForwardRef(ArrowDownIcon)'

--- a/src/icons/arrowLeftIcon.tsx
+++ b/src/icons/arrowLeftIcon.tsx
@@ -30,3 +30,4 @@ export const ArrowLeftIcon = forwardRef(function ArrowLeftIcon(
     </svg>
   )
 })
+ArrowLeftIcon.displayName = 'ForwardRef(ArrowLeftIcon)'

--- a/src/icons/arrowRightIcon.tsx
+++ b/src/icons/arrowRightIcon.tsx
@@ -30,3 +30,4 @@ export const ArrowRightIcon = forwardRef(function ArrowRightIcon(
     </svg>
   )
 })
+ArrowRightIcon.displayName = 'ForwardRef(ArrowRightIcon)'

--- a/src/icons/arrowTopRightIcon.tsx
+++ b/src/icons/arrowTopRightIcon.tsx
@@ -25,3 +25,4 @@ export const ArrowTopRightIcon = forwardRef(function ArrowTopRightIcon(
     </svg>
   )
 })
+ArrowTopRightIcon.displayName = 'ForwardRef(ArrowTopRightIcon)'

--- a/src/icons/arrowUpIcon.tsx
+++ b/src/icons/arrowUpIcon.tsx
@@ -30,3 +30,4 @@ export const ArrowUpIcon = forwardRef(function ArrowUpIcon(
     </svg>
   )
 })
+ArrowUpIcon.displayName = 'ForwardRef(ArrowUpIcon)'

--- a/src/icons/asteriskIcon.tsx
+++ b/src/icons/asteriskIcon.tsx
@@ -29,3 +29,4 @@ export const AsteriskIcon = forwardRef(function AsteriskIcon(
     </svg>
   )
 })
+AsteriskIcon.displayName = 'ForwardRef(AsteriskIcon)'

--- a/src/icons/barChartIcon.tsx
+++ b/src/icons/barChartIcon.tsx
@@ -29,3 +29,4 @@ export const BarChartIcon = forwardRef(function BarChartIcon(
     </svg>
   )
 })
+BarChartIcon.displayName = 'ForwardRef(BarChartIcon)'

--- a/src/icons/basketIcon.tsx
+++ b/src/icons/basketIcon.tsx
@@ -29,3 +29,4 @@ export const BasketIcon = forwardRef(function BasketIcon(
     </svg>
   )
 })
+BasketIcon.displayName = 'ForwardRef(BasketIcon)'

--- a/src/icons/bellIcon.tsx
+++ b/src/icons/bellIcon.tsx
@@ -29,3 +29,4 @@ export const BellIcon = forwardRef(function BellIcon(
     </svg>
   )
 })
+BellIcon.displayName = 'ForwardRef(BellIcon)'

--- a/src/icons/billIcon.tsx
+++ b/src/icons/billIcon.tsx
@@ -29,3 +29,4 @@ export const BillIcon = forwardRef(function BillIcon(
     </svg>
   )
 })
+BillIcon.displayName = 'ForwardRef(BillIcon)'

--- a/src/icons/binaryDocumentIcon.tsx
+++ b/src/icons/binaryDocumentIcon.tsx
@@ -31,3 +31,4 @@ export const BinaryDocumentIcon = forwardRef(function BinaryDocumentIcon(
     </svg>
   )
 })
+BinaryDocumentIcon.displayName = 'ForwardRef(BinaryDocumentIcon)'

--- a/src/icons/blockContentIcon.tsx
+++ b/src/icons/blockContentIcon.tsx
@@ -51,3 +51,4 @@ export const BlockContentIcon = forwardRef(function BlockContentIcon(
     </svg>
   )
 })
+BlockContentIcon.displayName = 'ForwardRef(BlockContentIcon)'

--- a/src/icons/blockElementIcon.tsx
+++ b/src/icons/blockElementIcon.tsx
@@ -29,3 +29,4 @@ export const BlockElementIcon = forwardRef(function BlockElementIcon(
     </svg>
   )
 })
+BlockElementIcon.displayName = 'ForwardRef(BlockElementIcon)'

--- a/src/icons/blockquoteIcon.tsx
+++ b/src/icons/blockquoteIcon.tsx
@@ -29,3 +29,4 @@ export const BlockquoteIcon = forwardRef(function BlockquoteIcon(
     </svg>
   )
 })
+BlockquoteIcon.displayName = 'ForwardRef(BlockquoteIcon)'

--- a/src/icons/boldIcon.tsx
+++ b/src/icons/boldIcon.tsx
@@ -27,3 +27,4 @@ export const BoldIcon = forwardRef(function BoldIcon(
     </svg>
   )
 })
+BoldIcon.displayName = 'ForwardRef(BoldIcon)'

--- a/src/icons/boltIcon.tsx
+++ b/src/icons/boltIcon.tsx
@@ -29,3 +29,4 @@ export const BoltIcon = forwardRef(function BoltIcon(
     </svg>
   )
 })
+BoltIcon.displayName = 'ForwardRef(BoltIcon)'

--- a/src/icons/bookIcon.tsx
+++ b/src/icons/bookIcon.tsx
@@ -29,3 +29,4 @@ export const BookIcon = forwardRef(function BookIcon(
     </svg>
   )
 })
+BookIcon.displayName = 'ForwardRef(BookIcon)'

--- a/src/icons/bottleIcon.tsx
+++ b/src/icons/bottleIcon.tsx
@@ -29,3 +29,4 @@ export const BottleIcon = forwardRef(function BottleIcon(
     </svg>
   )
 })
+BottleIcon.displayName = 'ForwardRef(BottleIcon)'

--- a/src/icons/bulbFilledIcon.tsx
+++ b/src/icons/bulbFilledIcon.tsx
@@ -33,3 +33,4 @@ export const BulbFilledIcon = forwardRef(function BulbFilledIcon(
     </svg>
   )
 })
+BulbFilledIcon.displayName = 'ForwardRef(BulbFilledIcon)'

--- a/src/icons/bulbOutlineIcon.tsx
+++ b/src/icons/bulbOutlineIcon.tsx
@@ -28,3 +28,4 @@ export const BulbOutlineIcon = forwardRef(function BulbOutlineIcon(
     </svg>
   )
 })
+BulbOutlineIcon.displayName = 'ForwardRef(BulbOutlineIcon)'

--- a/src/icons/calendarIcon.tsx
+++ b/src/icons/calendarIcon.tsx
@@ -29,3 +29,4 @@ export const CalendarIcon = forwardRef(function CalendarIcon(
     </svg>
   )
 })
+CalendarIcon.displayName = 'ForwardRef(CalendarIcon)'

--- a/src/icons/caseIcon.tsx
+++ b/src/icons/caseIcon.tsx
@@ -29,3 +29,4 @@ export const CaseIcon = forwardRef(function CaseIcon(
     </svg>
   )
 })
+CaseIcon.displayName = 'ForwardRef(CaseIcon)'

--- a/src/icons/chartUpwardIcon.tsx
+++ b/src/icons/chartUpwardIcon.tsx
@@ -29,3 +29,4 @@ export const ChartUpwardIcon = forwardRef(function ChartUpwardIcon(
     </svg>
   )
 })
+ChartUpwardIcon.displayName = 'ForwardRef(ChartUpwardIcon)'

--- a/src/icons/checkmarkCircleIcon.tsx
+++ b/src/icons/checkmarkCircleIcon.tsx
@@ -29,3 +29,4 @@ export const CheckmarkCircleIcon = forwardRef(function CheckmarkCircleIcon(
     </svg>
   )
 })
+CheckmarkCircleIcon.displayName = 'ForwardRef(CheckmarkCircleIcon)'

--- a/src/icons/checkmarkIcon.tsx
+++ b/src/icons/checkmarkIcon.tsx
@@ -29,3 +29,4 @@ export const CheckmarkIcon = forwardRef(function CheckmarkIcon(
     </svg>
   )
 })
+CheckmarkIcon.displayName = 'ForwardRef(CheckmarkIcon)'

--- a/src/icons/chevronDownIcon.tsx
+++ b/src/icons/chevronDownIcon.tsx
@@ -29,3 +29,4 @@ export const ChevronDownIcon = forwardRef(function ChevronDownIcon(
     </svg>
   )
 })
+ChevronDownIcon.displayName = 'ForwardRef(ChevronDownIcon)'

--- a/src/icons/chevronLeftIcon.tsx
+++ b/src/icons/chevronLeftIcon.tsx
@@ -29,3 +29,4 @@ export const ChevronLeftIcon = forwardRef(function ChevronLeftIcon(
     </svg>
   )
 })
+ChevronLeftIcon.displayName = 'ForwardRef(ChevronLeftIcon)'

--- a/src/icons/chevronRightIcon.tsx
+++ b/src/icons/chevronRightIcon.tsx
@@ -29,3 +29,4 @@ export const ChevronRightIcon = forwardRef(function ChevronRightIcon(
     </svg>
   )
 })
+ChevronRightIcon.displayName = 'ForwardRef(ChevronRightIcon)'

--- a/src/icons/chevronUpIcon.tsx
+++ b/src/icons/chevronUpIcon.tsx
@@ -29,3 +29,4 @@ export const ChevronUpIcon = forwardRef(function ChevronUpIcon(
     </svg>
   )
 })
+ChevronUpIcon.displayName = 'ForwardRef(ChevronUpIcon)'

--- a/src/icons/circleIcon.tsx
+++ b/src/icons/circleIcon.tsx
@@ -31,3 +31,4 @@ export const CircleIcon = forwardRef(function CircleIcon(
     </svg>
   )
 })
+CircleIcon.displayName = 'ForwardRef(CircleIcon)'

--- a/src/icons/clipboardIcon.tsx
+++ b/src/icons/clipboardIcon.tsx
@@ -29,3 +29,4 @@ export const ClipboardIcon = forwardRef(function ClipboardIcon(
     </svg>
   )
 })
+ClipboardIcon.displayName = 'ForwardRef(ClipboardIcon)'

--- a/src/icons/clipboardImageIcon.tsx
+++ b/src/icons/clipboardImageIcon.tsx
@@ -29,3 +29,4 @@ export const ClipboardImageIcon = forwardRef(function ClipboardImageIcon(
     </svg>
   )
 })
+ClipboardImageIcon.displayName = 'ForwardRef(ClipboardImageIcon)'

--- a/src/icons/clockIcon.tsx
+++ b/src/icons/clockIcon.tsx
@@ -29,3 +29,4 @@ export const ClockIcon = forwardRef(function ClockIcon(
     </svg>
   )
 })
+ClockIcon.displayName = 'ForwardRef(ClockIcon)'

--- a/src/icons/closeCircleIcon.tsx
+++ b/src/icons/closeCircleIcon.tsx
@@ -29,3 +29,4 @@ export const CloseCircleIcon = forwardRef(function CloseCircleIcon(
     </svg>
   )
 })
+CloseCircleIcon.displayName = 'ForwardRef(CloseCircleIcon)'

--- a/src/icons/closeIcon.tsx
+++ b/src/icons/closeIcon.tsx
@@ -29,3 +29,4 @@ export const CloseIcon = forwardRef(function CloseIcon(
     </svg>
   )
 })
+CloseIcon.displayName = 'ForwardRef(CloseIcon)'

--- a/src/icons/codeBlockIcon.tsx
+++ b/src/icons/codeBlockIcon.tsx
@@ -29,3 +29,4 @@ export const CodeBlockIcon = forwardRef(function CodeBlockIcon(
     </svg>
   )
 })
+CodeBlockIcon.displayName = 'ForwardRef(CodeBlockIcon)'

--- a/src/icons/codeIcon.tsx
+++ b/src/icons/codeIcon.tsx
@@ -29,3 +29,4 @@ export const CodeIcon = forwardRef(function CodeIcon(
     </svg>
   )
 })
+CodeIcon.displayName = 'ForwardRef(CodeIcon)'

--- a/src/icons/cogIcon.tsx
+++ b/src/icons/cogIcon.tsx
@@ -35,3 +35,4 @@ export const CogIcon = forwardRef(function CogIcon(
     </svg>
   )
 })
+CogIcon.displayName = 'ForwardRef(CogIcon)'

--- a/src/icons/collapseIcon.tsx
+++ b/src/icons/collapseIcon.tsx
@@ -35,3 +35,4 @@ export const CollapseIcon = forwardRef(function CollapseIcon(
     </svg>
   )
 })
+CollapseIcon.displayName = 'ForwardRef(CollapseIcon)'

--- a/src/icons/colorWheelIcon.tsx
+++ b/src/icons/colorWheelIcon.tsx
@@ -29,3 +29,4 @@ export const ColorWheelIcon = forwardRef(function ColorWheelIcon(
     </svg>
   )
 })
+ColorWheelIcon.displayName = 'ForwardRef(ColorWheelIcon)'

--- a/src/icons/commentIcon.tsx
+++ b/src/icons/commentIcon.tsx
@@ -29,3 +29,4 @@ export const CommentIcon = forwardRef(function CommentIcon(
     </svg>
   )
 })
+CommentIcon.displayName = 'ForwardRef(CommentIcon)'

--- a/src/icons/componentIcon.tsx
+++ b/src/icons/componentIcon.tsx
@@ -29,3 +29,4 @@ export const ComponentIcon = forwardRef(function ComponentIcon(
     </svg>
   )
 })
+ComponentIcon.displayName = 'ForwardRef(ComponentIcon)'

--- a/src/icons/composeIcon.tsx
+++ b/src/icons/composeIcon.tsx
@@ -29,3 +29,4 @@ export const ComposeIcon = forwardRef(function ComposeIcon(
     </svg>
   )
 })
+ComposeIcon.displayName = 'ForwardRef(ComposeIcon)'

--- a/src/icons/confettiIcon.tsx
+++ b/src/icons/confettiIcon.tsx
@@ -43,3 +43,4 @@ export const ConfettiIcon = forwardRef(function ConfettiIcon(
     </svg>
   )
 })
+ConfettiIcon.displayName = 'ForwardRef(ConfettiIcon)'

--- a/src/icons/controlsIcon.tsx
+++ b/src/icons/controlsIcon.tsx
@@ -29,3 +29,4 @@ export const ControlsIcon = forwardRef(function ControlsIcon(
     </svg>
   )
 })
+ControlsIcon.displayName = 'ForwardRef(ControlsIcon)'

--- a/src/icons/copyIcon.tsx
+++ b/src/icons/copyIcon.tsx
@@ -29,3 +29,4 @@ export const CopyIcon = forwardRef(function CopyIcon(
     </svg>
   )
 })
+CopyIcon.displayName = 'ForwardRef(CopyIcon)'

--- a/src/icons/creditCardIcon.tsx
+++ b/src/icons/creditCardIcon.tsx
@@ -36,3 +36,4 @@ export const CreditCardIcon = forwardRef(function CreditCardIcon(
     </svg>
   )
 })
+CreditCardIcon.displayName = 'ForwardRef(CreditCardIcon)'

--- a/src/icons/cropIcon.tsx
+++ b/src/icons/cropIcon.tsx
@@ -29,3 +29,4 @@ export const CropIcon = forwardRef(function CropIcon(
     </svg>
   )
 })
+CropIcon.displayName = 'ForwardRef(CropIcon)'

--- a/src/icons/cubeIcon.tsx
+++ b/src/icons/cubeIcon.tsx
@@ -35,3 +35,4 @@ export const CubeIcon = forwardRef(function CubeIcon(
     </svg>
   )
 })
+CubeIcon.displayName = 'ForwardRef(CubeIcon)'

--- a/src/icons/dashboardIcon.tsx
+++ b/src/icons/dashboardIcon.tsx
@@ -29,3 +29,4 @@ export const DashboardIcon = forwardRef(function DashboardIcon(
     </svg>
   )
 })
+DashboardIcon.displayName = 'ForwardRef(DashboardIcon)'

--- a/src/icons/databaseIcon.tsx
+++ b/src/icons/databaseIcon.tsx
@@ -29,3 +29,4 @@ export const DatabaseIcon = forwardRef(function DatabaseIcon(
     </svg>
   )
 })
+DatabaseIcon.displayName = 'ForwardRef(DatabaseIcon)'

--- a/src/icons/desktopIcon.tsx
+++ b/src/icons/desktopIcon.tsx
@@ -29,3 +29,4 @@ export const DesktopIcon = forwardRef(function DesktopIcon(
     </svg>
   )
 })
+DesktopIcon.displayName = 'ForwardRef(DesktopIcon)'

--- a/src/icons/diamondIcon.tsx
+++ b/src/icons/diamondIcon.tsx
@@ -29,3 +29,4 @@ export const DiamondIcon = forwardRef(function DiamondIcon(
     </svg>
   )
 })
+DiamondIcon.displayName = 'ForwardRef(DiamondIcon)'

--- a/src/icons/documentIcon.tsx
+++ b/src/icons/documentIcon.tsx
@@ -30,3 +30,4 @@ export const DocumentIcon = forwardRef(function DocumentIcon(
     </svg>
   )
 })
+DocumentIcon.displayName = 'ForwardRef(DocumentIcon)'

--- a/src/icons/documentPdfIcon.tsx
+++ b/src/icons/documentPdfIcon.tsx
@@ -34,3 +34,4 @@ export const DocumentPdfIcon = forwardRef(function DocumentPdfIcon(
     </svg>
   )
 })
+DocumentPdfIcon.displayName = 'ForwardRef(DocumentPdfIcon)'

--- a/src/icons/documentRemoveIcon.tsx
+++ b/src/icons/documentRemoveIcon.tsx
@@ -30,3 +30,4 @@ export const DocumentRemoveIcon = forwardRef(function DocumentRemoveIcon(
     </svg>
   )
 })
+DocumentRemoveIcon.displayName = 'ForwardRef(DocumentRemoveIcon)'

--- a/src/icons/documentSheetIcon.tsx
+++ b/src/icons/documentSheetIcon.tsx
@@ -30,3 +30,4 @@ export const DocumentSheetIcon = forwardRef(function DocumentSheetIcon(
     </svg>
   )
 })
+DocumentSheetIcon.displayName = 'ForwardRef(DocumentSheetIcon)'

--- a/src/icons/documentTextIcon.tsx
+++ b/src/icons/documentTextIcon.tsx
@@ -30,3 +30,4 @@ export const DocumentTextIcon = forwardRef(function DocumentTextIcon(
     </svg>
   )
 })
+DocumentTextIcon.displayName = 'ForwardRef(DocumentTextIcon)'

--- a/src/icons/documentVideoIcon.tsx
+++ b/src/icons/documentVideoIcon.tsx
@@ -36,3 +36,4 @@ export const DocumentVideoIcon = forwardRef(function DocumentVideoIcon(
     </svg>
   )
 })
+DocumentVideoIcon.displayName = 'ForwardRef(DocumentVideoIcon)'

--- a/src/icons/documentWordIcon.tsx
+++ b/src/icons/documentWordIcon.tsx
@@ -34,3 +34,4 @@ export const DocumentWordIcon = forwardRef(function DocumentWordIcon(
     </svg>
   )
 })
+DocumentWordIcon.displayName = 'ForwardRef(DocumentWordIcon)'

--- a/src/icons/documentZipIcon.tsx
+++ b/src/icons/documentZipIcon.tsx
@@ -30,3 +30,4 @@ export const DocumentZipIcon = forwardRef(function DocumentZipIcon(
     </svg>
   )
 })
+DocumentZipIcon.displayName = 'ForwardRef(DocumentZipIcon)'

--- a/src/icons/documentsIcon.tsx
+++ b/src/icons/documentsIcon.tsx
@@ -30,3 +30,4 @@ export const DocumentsIcon = forwardRef(function DocumentsIcon(
     </svg>
   )
 })
+DocumentsIcon.displayName = 'ForwardRef(DocumentsIcon)'

--- a/src/icons/dotIcon.tsx
+++ b/src/icons/dotIcon.tsx
@@ -31,3 +31,4 @@ export const DotIcon = forwardRef(function DotIcon(
     </svg>
   )
 })
+DotIcon.displayName = 'ForwardRef(DotIcon)'

--- a/src/icons/doubleChevronDownIcon.tsx
+++ b/src/icons/doubleChevronDownIcon.tsx
@@ -29,3 +29,4 @@ export const DoubleChevronDownIcon = forwardRef(function DoubleChevronDownIcon(
     </svg>
   )
 })
+DoubleChevronDownIcon.displayName = 'ForwardRef(DoubleChevronDownIcon)'

--- a/src/icons/doubleChevronLeftIcon.tsx
+++ b/src/icons/doubleChevronLeftIcon.tsx
@@ -29,3 +29,4 @@ export const DoubleChevronLeftIcon = forwardRef(function DoubleChevronLeftIcon(
     </svg>
   )
 })
+DoubleChevronLeftIcon.displayName = 'ForwardRef(DoubleChevronLeftIcon)'

--- a/src/icons/doubleChevronRightIcon.tsx
+++ b/src/icons/doubleChevronRightIcon.tsx
@@ -29,3 +29,4 @@ export const DoubleChevronRightIcon = forwardRef(function DoubleChevronRightIcon
     </svg>
   )
 })
+DoubleChevronRightIcon.displayName = 'ForwardRef(DoubleChevronRightIcon)'

--- a/src/icons/doubleChevronUpIcon.tsx
+++ b/src/icons/doubleChevronUpIcon.tsx
@@ -29,3 +29,4 @@ export const DoubleChevronUpIcon = forwardRef(function DoubleChevronUpIcon(
     </svg>
   )
 })
+DoubleChevronUpIcon.displayName = 'ForwardRef(DoubleChevronUpIcon)'

--- a/src/icons/downloadIcon.tsx
+++ b/src/icons/downloadIcon.tsx
@@ -35,3 +35,4 @@ export const DownloadIcon = forwardRef(function DownloadIcon(
     </svg>
   )
 })
+DownloadIcon.displayName = 'ForwardRef(DownloadIcon)'

--- a/src/icons/dragHandleIcon.tsx
+++ b/src/icons/dragHandleIcon.tsx
@@ -47,3 +47,4 @@ export const DragHandleIcon = forwardRef(function DragHandleIcon(
     </svg>
   )
 })
+DragHandleIcon.displayName = 'ForwardRef(DragHandleIcon)'

--- a/src/icons/dropIcon.tsx
+++ b/src/icons/dropIcon.tsx
@@ -29,3 +29,4 @@ export const DropIcon = forwardRef(function DropIcon(
     </svg>
   )
 })
+DropIcon.displayName = 'ForwardRef(DropIcon)'

--- a/src/icons/earthAmericasIcon.tsx
+++ b/src/icons/earthAmericasIcon.tsx
@@ -38,3 +38,4 @@ export const EarthAmericasIcon = forwardRef(function EarthAmericasIcon(
     </svg>
   )
 })
+EarthAmericasIcon.displayName = 'ForwardRef(EarthAmericasIcon)'

--- a/src/icons/earthGlobeIcon.tsx
+++ b/src/icons/earthGlobeIcon.tsx
@@ -29,3 +29,4 @@ export const EarthGlobeIcon = forwardRef(function EarthGlobeIcon(
     </svg>
   )
 })
+EarthGlobeIcon.displayName = 'ForwardRef(EarthGlobeIcon)'

--- a/src/icons/editIcon.tsx
+++ b/src/icons/editIcon.tsx
@@ -29,3 +29,4 @@ export const EditIcon = forwardRef(function EditIcon(
     </svg>
   )
 })
+EditIcon.displayName = 'ForwardRef(EditIcon)'

--- a/src/icons/ellipsisHorizontalIcon.tsx
+++ b/src/icons/ellipsisHorizontalIcon.tsx
@@ -35,3 +35,4 @@ export const EllipsisHorizontalIcon = forwardRef(function EllipsisHorizontalIcon
     </svg>
   )
 })
+EllipsisHorizontalIcon.displayName = 'ForwardRef(EllipsisHorizontalIcon)'

--- a/src/icons/ellipsisVerticalIcon.tsx
+++ b/src/icons/ellipsisVerticalIcon.tsx
@@ -35,3 +35,4 @@ export const EllipsisVerticalIcon = forwardRef(function EllipsisVerticalIcon(
     </svg>
   )
 })
+EllipsisVerticalIcon.displayName = 'ForwardRef(EllipsisVerticalIcon)'

--- a/src/icons/emptyIcon.tsx
+++ b/src/icons/emptyIcon.tsx
@@ -28,3 +28,4 @@ export const EmptyIcon = forwardRef(function EmptyIcon(
     </svg>
   )
 })
+EmptyIcon.displayName = 'ForwardRef(EmptyIcon)'

--- a/src/icons/enterIcon.tsx
+++ b/src/icons/enterIcon.tsx
@@ -30,3 +30,4 @@ export const EnterIcon = forwardRef(function EnterIcon(
     </svg>
   )
 })
+EnterIcon.displayName = 'ForwardRef(EnterIcon)'

--- a/src/icons/enterRightIcon.tsx
+++ b/src/icons/enterRightIcon.tsx
@@ -30,3 +30,4 @@ export const EnterRightIcon = forwardRef(function EnterRightIcon(
     </svg>
   )
 })
+EnterRightIcon.displayName = 'ForwardRef(EnterRightIcon)'

--- a/src/icons/envelopeIcon.tsx
+++ b/src/icons/envelopeIcon.tsx
@@ -35,3 +35,4 @@ export const EnvelopeIcon = forwardRef(function EnvelopeIcon(
     </svg>
   )
 })
+EnvelopeIcon.displayName = 'ForwardRef(EnvelopeIcon)'

--- a/src/icons/equalIcon.tsx
+++ b/src/icons/equalIcon.tsx
@@ -27,3 +27,4 @@ export const EqualIcon = forwardRef(function EqualIcon(
     </svg>
   )
 })
+EqualIcon.displayName = 'ForwardRef(EqualIcon)'

--- a/src/icons/errorFilledIcon.tsx
+++ b/src/icons/errorFilledIcon.tsx
@@ -29,3 +29,4 @@ export const ErrorFilledIcon = forwardRef(function ErrorFilledIcon(
     </svg>
   )
 })
+ErrorFilledIcon.displayName = 'ForwardRef(ErrorFilledIcon)'

--- a/src/icons/errorOutlineIcon.tsx
+++ b/src/icons/errorOutlineIcon.tsx
@@ -29,3 +29,4 @@ export const ErrorOutlineIcon = forwardRef(function ErrorOutlineIcon(
     </svg>
   )
 })
+ErrorOutlineIcon.displayName = 'ForwardRef(ErrorOutlineIcon)'

--- a/src/icons/expandIcon.tsx
+++ b/src/icons/expandIcon.tsx
@@ -35,3 +35,4 @@ export const ExpandIcon = forwardRef(function ExpandIcon(
     </svg>
   )
 })
+ExpandIcon.displayName = 'ForwardRef(ExpandIcon)'

--- a/src/icons/eyeClosedIcon.tsx
+++ b/src/icons/eyeClosedIcon.tsx
@@ -29,3 +29,4 @@ export const EyeClosedIcon = forwardRef(function EyeClosedIcon(
     </svg>
   )
 })
+EyeClosedIcon.displayName = 'ForwardRef(EyeClosedIcon)'

--- a/src/icons/eyeOpenIcon.tsx
+++ b/src/icons/eyeOpenIcon.tsx
@@ -35,3 +35,4 @@ export const EyeOpenIcon = forwardRef(function EyeOpenIcon(
     </svg>
   )
 })
+EyeOpenIcon.displayName = 'ForwardRef(EyeOpenIcon)'

--- a/src/icons/filterIcon.tsx
+++ b/src/icons/filterIcon.tsx
@@ -30,3 +30,4 @@ export const FilterIcon = forwardRef(function FilterIcon(
     </svg>
   )
 })
+FilterIcon.displayName = 'ForwardRef(FilterIcon)'

--- a/src/icons/folderIcon.tsx
+++ b/src/icons/folderIcon.tsx
@@ -29,3 +29,4 @@ export const FolderIcon = forwardRef(function FolderIcon(
     </svg>
   )
 })
+FolderIcon.displayName = 'ForwardRef(FolderIcon)'

--- a/src/icons/generateIcon.tsx
+++ b/src/icons/generateIcon.tsx
@@ -35,3 +35,4 @@ export const GenerateIcon = forwardRef(function GenerateIcon(
     </svg>
   )
 })
+GenerateIcon.displayName = 'ForwardRef(GenerateIcon)'

--- a/src/icons/groqIcon.tsx
+++ b/src/icons/groqIcon.tsx
@@ -26,3 +26,4 @@ export const GroqIcon = forwardRef(function GroqIcon(
     </svg>
   )
 })
+GroqIcon.displayName = 'ForwardRef(GroqIcon)'

--- a/src/icons/hashIcon.tsx
+++ b/src/icons/hashIcon.tsx
@@ -29,3 +29,4 @@ export const HashIcon = forwardRef(function HashIcon(
     </svg>
   )
 })
+HashIcon.displayName = 'ForwardRef(HashIcon)'

--- a/src/icons/heartFilledIcon.tsx
+++ b/src/icons/heartFilledIcon.tsx
@@ -30,3 +30,4 @@ export const HeartFilledIcon = forwardRef(function HeartFilledIcon(
     </svg>
   )
 })
+HeartFilledIcon.displayName = 'ForwardRef(HeartFilledIcon)'

--- a/src/icons/heartIcon.tsx
+++ b/src/icons/heartIcon.tsx
@@ -29,3 +29,4 @@ export const HeartIcon = forwardRef(function HeartIcon(
     </svg>
   )
 })
+HeartIcon.displayName = 'ForwardRef(HeartIcon)'

--- a/src/icons/helpCircleIcon.tsx
+++ b/src/icons/helpCircleIcon.tsx
@@ -29,3 +29,4 @@ export const HelpCircleIcon = forwardRef(function HelpCircleIcon(
     </svg>
   )
 })
+HelpCircleIcon.displayName = 'ForwardRef(HelpCircleIcon)'

--- a/src/icons/highlightIcon.tsx
+++ b/src/icons/highlightIcon.tsx
@@ -29,3 +29,4 @@ export const HighlightIcon = forwardRef(function HighlightIcon(
     </svg>
   )
 })
+HighlightIcon.displayName = 'ForwardRef(HighlightIcon)'

--- a/src/icons/homeIcon.tsx
+++ b/src/icons/homeIcon.tsx
@@ -29,3 +29,4 @@ export const HomeIcon = forwardRef(function HomeIcon(
     </svg>
   )
 })
+HomeIcon.displayName = 'ForwardRef(HomeIcon)'

--- a/src/icons/iceCreamIcon.tsx
+++ b/src/icons/iceCreamIcon.tsx
@@ -29,3 +29,4 @@ export const IceCreamIcon = forwardRef(function IceCreamIcon(
     </svg>
   )
 })
+IceCreamIcon.displayName = 'ForwardRef(IceCreamIcon)'

--- a/src/icons/imageIcon.tsx
+++ b/src/icons/imageIcon.tsx
@@ -29,3 +29,4 @@ export const ImageIcon = forwardRef(function ImageIcon(
     </svg>
   )
 })
+ImageIcon.displayName = 'ForwardRef(ImageIcon)'

--- a/src/icons/imageRemoveIcon.tsx
+++ b/src/icons/imageRemoveIcon.tsx
@@ -29,3 +29,4 @@ export const ImageRemoveIcon = forwardRef(function ImageRemoveIcon(
     </svg>
   )
 })
+ImageRemoveIcon.displayName = 'ForwardRef(ImageRemoveIcon)'

--- a/src/icons/imagesIcon.tsx
+++ b/src/icons/imagesIcon.tsx
@@ -29,3 +29,4 @@ export const ImagesIcon = forwardRef(function ImagesIcon(
     </svg>
   )
 })
+ImagesIcon.displayName = 'ForwardRef(ImagesIcon)'

--- a/src/icons/infoFilledIcon.tsx
+++ b/src/icons/infoFilledIcon.tsx
@@ -29,3 +29,4 @@ export const InfoFilledIcon = forwardRef(function InfoFilledIcon(
     </svg>
   )
 })
+InfoFilledIcon.displayName = 'ForwardRef(InfoFilledIcon)'

--- a/src/icons/infoOutlineIcon.tsx
+++ b/src/icons/infoOutlineIcon.tsx
@@ -29,3 +29,4 @@ export const InfoOutlineIcon = forwardRef(function InfoOutlineIcon(
     </svg>
   )
 })
+InfoOutlineIcon.displayName = 'ForwardRef(InfoOutlineIcon)'

--- a/src/icons/inlineElementIcon.tsx
+++ b/src/icons/inlineElementIcon.tsx
@@ -29,3 +29,4 @@ export const InlineElementIcon = forwardRef(function InlineElementIcon(
     </svg>
   )
 })
+InlineElementIcon.displayName = 'ForwardRef(InlineElementIcon)'

--- a/src/icons/inlineIcon.tsx
+++ b/src/icons/inlineIcon.tsx
@@ -29,3 +29,4 @@ export const InlineIcon = forwardRef(function InlineIcon(
     </svg>
   )
 })
+InlineIcon.displayName = 'ForwardRef(InlineIcon)'

--- a/src/icons/insertAboveIcon.tsx
+++ b/src/icons/insertAboveIcon.tsx
@@ -30,3 +30,4 @@ export const InsertAboveIcon = forwardRef(function InsertAboveIcon(
     </svg>
   )
 })
+InsertAboveIcon.displayName = 'ForwardRef(InsertAboveIcon)'

--- a/src/icons/insertBelowIcon.tsx
+++ b/src/icons/insertBelowIcon.tsx
@@ -30,3 +30,4 @@ export const InsertBelowIcon = forwardRef(function InsertBelowIcon(
     </svg>
   )
 })
+InsertBelowIcon.displayName = 'ForwardRef(InsertBelowIcon)'

--- a/src/icons/italicIcon.tsx
+++ b/src/icons/italicIcon.tsx
@@ -27,3 +27,4 @@ export const ItalicIcon = forwardRef(function ItalicIcon(
     </svg>
   )
 })
+ItalicIcon.displayName = 'ForwardRef(ItalicIcon)'

--- a/src/icons/joystickIcon.tsx
+++ b/src/icons/joystickIcon.tsx
@@ -29,3 +29,4 @@ export const JoystickIcon = forwardRef(function JoystickIcon(
     </svg>
   )
 })
+JoystickIcon.displayName = 'ForwardRef(JoystickIcon)'

--- a/src/icons/jsonIcon.tsx
+++ b/src/icons/jsonIcon.tsx
@@ -29,3 +29,4 @@ export const JsonIcon = forwardRef(function JsonIcon(
     </svg>
   )
 })
+JsonIcon.displayName = 'ForwardRef(JsonIcon)'

--- a/src/icons/launchIcon.tsx
+++ b/src/icons/launchIcon.tsx
@@ -30,3 +30,4 @@ export const LaunchIcon = forwardRef(function LaunchIcon(
     </svg>
   )
 })
+LaunchIcon.displayName = 'ForwardRef(LaunchIcon)'

--- a/src/icons/leaveIcon.tsx
+++ b/src/icons/leaveIcon.tsx
@@ -35,3 +35,4 @@ export const LeaveIcon = forwardRef(function LeaveIcon(
     </svg>
   )
 })
+LeaveIcon.displayName = 'ForwardRef(LeaveIcon)'

--- a/src/icons/lemonIcon.tsx
+++ b/src/icons/lemonIcon.tsx
@@ -29,3 +29,4 @@ export const LemonIcon = forwardRef(function LemonIcon(
     </svg>
   )
 })
+LemonIcon.displayName = 'ForwardRef(LemonIcon)'

--- a/src/icons/linkIcon.tsx
+++ b/src/icons/linkIcon.tsx
@@ -29,3 +29,4 @@ export const LinkIcon = forwardRef(function LinkIcon(
     </svg>
   )
 })
+LinkIcon.displayName = 'ForwardRef(LinkIcon)'

--- a/src/icons/linkRemovedIcon.tsx
+++ b/src/icons/linkRemovedIcon.tsx
@@ -29,3 +29,4 @@ export const LinkRemovedIcon = forwardRef(function LinkRemovedIcon(
     </svg>
   )
 })
+LinkRemovedIcon.displayName = 'ForwardRef(LinkRemovedIcon)'

--- a/src/icons/lockIcon.tsx
+++ b/src/icons/lockIcon.tsx
@@ -29,3 +29,4 @@ export const LockIcon = forwardRef(function LockIcon(
     </svg>
   )
 })
+LockIcon.displayName = 'ForwardRef(LockIcon)'

--- a/src/icons/logoJsIcon.tsx
+++ b/src/icons/logoJsIcon.tsx
@@ -29,3 +29,4 @@ export const LogoJsIcon = forwardRef(function LogoJsIcon(
     </svg>
   )
 })
+LogoJsIcon.displayName = 'ForwardRef(LogoJsIcon)'

--- a/src/icons/logoTsIcon.tsx
+++ b/src/icons/logoTsIcon.tsx
@@ -29,3 +29,4 @@ export const LogoTsIcon = forwardRef(function LogoTsIcon(
     </svg>
   )
 })
+LogoTsIcon.displayName = 'ForwardRef(LogoTsIcon)'

--- a/src/icons/masterDetailIcon.tsx
+++ b/src/icons/masterDetailIcon.tsx
@@ -29,3 +29,4 @@ export const MasterDetailIcon = forwardRef(function MasterDetailIcon(
     </svg>
   )
 })
+MasterDetailIcon.displayName = 'ForwardRef(MasterDetailIcon)'

--- a/src/icons/menuIcon.tsx
+++ b/src/icons/menuIcon.tsx
@@ -29,3 +29,4 @@ export const MenuIcon = forwardRef(function MenuIcon(
     </svg>
   )
 })
+MenuIcon.displayName = 'ForwardRef(MenuIcon)'

--- a/src/icons/mobileDeviceIcon.tsx
+++ b/src/icons/mobileDeviceIcon.tsx
@@ -35,3 +35,4 @@ export const MobileDeviceIcon = forwardRef(function MobileDeviceIcon(
     </svg>
   )
 })
+MobileDeviceIcon.displayName = 'ForwardRef(MobileDeviceIcon)'

--- a/src/icons/moonIcon.tsx
+++ b/src/icons/moonIcon.tsx
@@ -29,3 +29,4 @@ export const MoonIcon = forwardRef(function MoonIcon(
     </svg>
   )
 })
+MoonIcon.displayName = 'ForwardRef(MoonIcon)'

--- a/src/icons/numberIcon.tsx
+++ b/src/icons/numberIcon.tsx
@@ -41,3 +41,4 @@ export const NumberIcon = forwardRef(function NumberIcon(
     </svg>
   )
 })
+NumberIcon.displayName = 'ForwardRef(NumberIcon)'

--- a/src/icons/okHandIcon.tsx
+++ b/src/icons/okHandIcon.tsx
@@ -29,3 +29,4 @@ export const OkHandIcon = forwardRef(function OkHandIcon(
     </svg>
   )
 })
+OkHandIcon.displayName = 'ForwardRef(OkHandIcon)'

--- a/src/icons/olistIcon.tsx
+++ b/src/icons/olistIcon.tsx
@@ -29,3 +29,4 @@ export const OlistIcon = forwardRef(function OlistIcon(
     </svg>
   )
 })
+OlistIcon.displayName = 'ForwardRef(OlistIcon)'

--- a/src/icons/overageIcon.tsx
+++ b/src/icons/overageIcon.tsx
@@ -30,3 +30,4 @@ export const OverageIcon = forwardRef(function OverageIcon(
     </svg>
   )
 })
+OverageIcon.displayName = 'ForwardRef(OverageIcon)'

--- a/src/icons/packageIcon.tsx
+++ b/src/icons/packageIcon.tsx
@@ -29,3 +29,4 @@ export const PackageIcon = forwardRef(function PackageIcon(
     </svg>
   )
 })
+PackageIcon.displayName = 'ForwardRef(PackageIcon)'

--- a/src/icons/panelLeftIcon.tsx
+++ b/src/icons/panelLeftIcon.tsx
@@ -29,3 +29,4 @@ export const PanelLeftIcon = forwardRef(function PanelLeftIcon(
     </svg>
   )
 })
+PanelLeftIcon.displayName = 'ForwardRef(PanelLeftIcon)'

--- a/src/icons/panelRightIcon.tsx
+++ b/src/icons/panelRightIcon.tsx
@@ -29,3 +29,4 @@ export const PanelRightIcon = forwardRef(function PanelRightIcon(
     </svg>
   )
 })
+PanelRightIcon.displayName = 'ForwardRef(PanelRightIcon)'

--- a/src/icons/pauseIcon.tsx
+++ b/src/icons/pauseIcon.tsx
@@ -27,3 +27,4 @@ export const PauseIcon = forwardRef(function PauseIcon(
     </svg>
   )
 })
+PauseIcon.displayName = 'ForwardRef(PauseIcon)'

--- a/src/icons/pinIcon.tsx
+++ b/src/icons/pinIcon.tsx
@@ -35,3 +35,4 @@ export const PinIcon = forwardRef(function PinIcon(
     </svg>
   )
 })
+PinIcon.displayName = 'ForwardRef(PinIcon)'

--- a/src/icons/pinRemovedIcon.tsx
+++ b/src/icons/pinRemovedIcon.tsx
@@ -29,3 +29,4 @@ export const PinRemovedIcon = forwardRef(function PinRemovedIcon(
     </svg>
   )
 })
+PinRemovedIcon.displayName = 'ForwardRef(PinRemovedIcon)'

--- a/src/icons/playIcon.tsx
+++ b/src/icons/playIcon.tsx
@@ -30,3 +30,4 @@ export const PlayIcon = forwardRef(function PlayIcon(
     </svg>
   )
 })
+PlayIcon.displayName = 'ForwardRef(PlayIcon)'

--- a/src/icons/plugIcon.tsx
+++ b/src/icons/plugIcon.tsx
@@ -29,3 +29,4 @@ export const PlugIcon = forwardRef(function PlugIcon(
     </svg>
   )
 })
+PlugIcon.displayName = 'ForwardRef(PlugIcon)'

--- a/src/icons/presentationIcon.tsx
+++ b/src/icons/presentationIcon.tsx
@@ -29,3 +29,4 @@ export const PresentationIcon = forwardRef(function PresentationIcon(
     </svg>
   )
 })
+PresentationIcon.displayName = 'ForwardRef(PresentationIcon)'

--- a/src/icons/progress50Icon.tsx
+++ b/src/icons/progress50Icon.tsx
@@ -36,3 +36,4 @@ export const Progress50Icon = forwardRef(function Progress50Icon(
     </svg>
   )
 })
+Progress50Icon.displayName = 'ForwardRef(Progress50Icon)'

--- a/src/icons/progress75Icon.tsx
+++ b/src/icons/progress75Icon.tsx
@@ -36,3 +36,4 @@ export const Progress75Icon = forwardRef(function Progress75Icon(
     </svg>
   )
 })
+Progress75Icon.displayName = 'ForwardRef(Progress75Icon)'

--- a/src/icons/projectsIcon.tsx
+++ b/src/icons/projectsIcon.tsx
@@ -29,3 +29,4 @@ export const ProjectsIcon = forwardRef(function ProjectsIcon(
     </svg>
   )
 })
+ProjectsIcon.displayName = 'ForwardRef(ProjectsIcon)'

--- a/src/icons/publishIcon.tsx
+++ b/src/icons/publishIcon.tsx
@@ -35,3 +35,4 @@ export const PublishIcon = forwardRef(function PublishIcon(
     </svg>
   )
 })
+PublishIcon.displayName = 'ForwardRef(PublishIcon)'

--- a/src/icons/readOnlyIcon.tsx
+++ b/src/icons/readOnlyIcon.tsx
@@ -29,3 +29,4 @@ export const ReadOnlyIcon = forwardRef(function ReadOnlyIcon(
     </svg>
   )
 })
+ReadOnlyIcon.displayName = 'ForwardRef(ReadOnlyIcon)'

--- a/src/icons/redoIcon.tsx
+++ b/src/icons/redoIcon.tsx
@@ -35,3 +35,4 @@ export const RedoIcon = forwardRef(function RedoIcon(
     </svg>
   )
 })
+RedoIcon.displayName = 'ForwardRef(RedoIcon)'

--- a/src/icons/refreshIcon.tsx
+++ b/src/icons/refreshIcon.tsx
@@ -35,3 +35,4 @@ export const RefreshIcon = forwardRef(function RefreshIcon(
     </svg>
   )
 })
+RefreshIcon.displayName = 'ForwardRef(RefreshIcon)'

--- a/src/icons/removeCircleIcon.tsx
+++ b/src/icons/removeCircleIcon.tsx
@@ -29,3 +29,4 @@ export const RemoveCircleIcon = forwardRef(function RemoveCircleIcon(
     </svg>
   )
 })
+RemoveCircleIcon.displayName = 'ForwardRef(RemoveCircleIcon)'

--- a/src/icons/removeIcon.tsx
+++ b/src/icons/removeIcon.tsx
@@ -24,3 +24,4 @@ export const RemoveIcon = forwardRef(function RemoveIcon(
     </svg>
   )
 })
+RemoveIcon.displayName = 'ForwardRef(RemoveIcon)'

--- a/src/icons/resetIcon.tsx
+++ b/src/icons/resetIcon.tsx
@@ -27,3 +27,4 @@ export const ResetIcon = forwardRef(function ResetIcon(
     </svg>
   )
 })
+ResetIcon.displayName = 'ForwardRef(ResetIcon)'

--- a/src/icons/restoreIcon.tsx
+++ b/src/icons/restoreIcon.tsx
@@ -35,3 +35,4 @@ export const RestoreIcon = forwardRef(function RestoreIcon(
     </svg>
   )
 })
+RestoreIcon.displayName = 'ForwardRef(RestoreIcon)'

--- a/src/icons/retrieveIcon.tsx
+++ b/src/icons/retrieveIcon.tsx
@@ -35,3 +35,4 @@ export const RetrieveIcon = forwardRef(function RetrieveIcon(
     </svg>
   )
 })
+RetrieveIcon.displayName = 'ForwardRef(RetrieveIcon)'

--- a/src/icons/retryIcon.tsx
+++ b/src/icons/retryIcon.tsx
@@ -35,3 +35,4 @@ export const RetryIcon = forwardRef(function RetryIcon(
     </svg>
   )
 })
+RetryIcon.displayName = 'ForwardRef(RetryIcon)'

--- a/src/icons/revertIcon.tsx
+++ b/src/icons/revertIcon.tsx
@@ -35,3 +35,4 @@ export const RevertIcon = forwardRef(function RevertIcon(
     </svg>
   )
 })
+RevertIcon.displayName = 'ForwardRef(RevertIcon)'

--- a/src/icons/robotIcon.tsx
+++ b/src/icons/robotIcon.tsx
@@ -29,3 +29,4 @@ export const RobotIcon = forwardRef(function RobotIcon(
     </svg>
   )
 })
+RobotIcon.displayName = 'ForwardRef(RobotIcon)'

--- a/src/icons/rocketIcon.tsx
+++ b/src/icons/rocketIcon.tsx
@@ -29,3 +29,4 @@ export const RocketIcon = forwardRef(function RocketIcon(
     </svg>
   )
 })
+RocketIcon.displayName = 'ForwardRef(RocketIcon)'

--- a/src/icons/schemaIcon.tsx
+++ b/src/icons/schemaIcon.tsx
@@ -29,3 +29,4 @@ export const SchemaIcon = forwardRef(function SchemaIcon(
     </svg>
   )
 })
+SchemaIcon.displayName = 'ForwardRef(SchemaIcon)'

--- a/src/icons/searchIcon.tsx
+++ b/src/icons/searchIcon.tsx
@@ -29,3 +29,4 @@ export const SearchIcon = forwardRef(function SearchIcon(
     </svg>
   )
 })
+SearchIcon.displayName = 'ForwardRef(SearchIcon)'

--- a/src/icons/selectIcon.tsx
+++ b/src/icons/selectIcon.tsx
@@ -29,3 +29,4 @@ export const SelectIcon = forwardRef(function SelectIcon(
     </svg>
   )
 })
+SelectIcon.displayName = 'ForwardRef(SelectIcon)'

--- a/src/icons/shareIcon.tsx
+++ b/src/icons/shareIcon.tsx
@@ -30,3 +30,4 @@ export const ShareIcon = forwardRef(function ShareIcon(
     </svg>
   )
 })
+ShareIcon.displayName = 'ForwardRef(ShareIcon)'

--- a/src/icons/sortIcon.tsx
+++ b/src/icons/sortIcon.tsx
@@ -29,3 +29,4 @@ export const SortIcon = forwardRef(function SortIcon(
     </svg>
   )
 })
+SortIcon.displayName = 'ForwardRef(SortIcon)'

--- a/src/icons/sparkleIcon.tsx
+++ b/src/icons/sparkleIcon.tsx
@@ -29,3 +29,4 @@ export const SparkleIcon = forwardRef(function SparkleIcon(
     </svg>
   )
 })
+SparkleIcon.displayName = 'ForwardRef(SparkleIcon)'

--- a/src/icons/sparklesIcon.tsx
+++ b/src/icons/sparklesIcon.tsx
@@ -30,3 +30,4 @@ export const SparklesIcon = forwardRef(function SparklesIcon(
     </svg>
   )
 })
+SparklesIcon.displayName = 'ForwardRef(SparklesIcon)'

--- a/src/icons/spinnerIcon.tsx
+++ b/src/icons/spinnerIcon.tsx
@@ -29,3 +29,4 @@ export const SpinnerIcon = forwardRef(function SpinnerIcon(
     </svg>
   )
 })
+SpinnerIcon.displayName = 'ForwardRef(SpinnerIcon)'

--- a/src/icons/splitHorizontalIcon.tsx
+++ b/src/icons/splitHorizontalIcon.tsx
@@ -29,3 +29,4 @@ export const SplitHorizontalIcon = forwardRef(function SplitHorizontalIcon(
     </svg>
   )
 })
+SplitHorizontalIcon.displayName = 'ForwardRef(SplitHorizontalIcon)'

--- a/src/icons/splitVerticalIcon.tsx
+++ b/src/icons/splitVerticalIcon.tsx
@@ -29,3 +29,4 @@ export const SplitVerticalIcon = forwardRef(function SplitVerticalIcon(
     </svg>
   )
 })
+SplitVerticalIcon.displayName = 'ForwardRef(SplitVerticalIcon)'

--- a/src/icons/squareIcon.tsx
+++ b/src/icons/squareIcon.tsx
@@ -32,3 +32,4 @@ export const SquareIcon = forwardRef(function SquareIcon(
     </svg>
   )
 })
+SquareIcon.displayName = 'ForwardRef(SquareIcon)'

--- a/src/icons/stackCompactIcon.tsx
+++ b/src/icons/stackCompactIcon.tsx
@@ -29,3 +29,4 @@ export const StackCompactIcon = forwardRef(function StackCompactIcon(
     </svg>
   )
 })
+StackCompactIcon.displayName = 'ForwardRef(StackCompactIcon)'

--- a/src/icons/stackIcon.tsx
+++ b/src/icons/stackIcon.tsx
@@ -29,3 +29,4 @@ export const StackIcon = forwardRef(function StackIcon(
     </svg>
   )
 })
+StackIcon.displayName = 'ForwardRef(StackIcon)'

--- a/src/icons/starFilledIcon.tsx
+++ b/src/icons/starFilledIcon.tsx
@@ -29,3 +29,4 @@ export const StarFilledIcon = forwardRef(function StarFilledIcon(
     </svg>
   )
 })
+StarFilledIcon.displayName = 'ForwardRef(StarFilledIcon)'

--- a/src/icons/starIcon.tsx
+++ b/src/icons/starIcon.tsx
@@ -29,3 +29,4 @@ export const StarIcon = forwardRef(function StarIcon(
     </svg>
   )
 })
+StarIcon.displayName = 'ForwardRef(StarIcon)'

--- a/src/icons/stopIcon.tsx
+++ b/src/icons/stopIcon.tsx
@@ -33,3 +33,4 @@ export const StopIcon = forwardRef(function StopIcon(
     </svg>
   )
 })
+StopIcon.displayName = 'ForwardRef(StopIcon)'

--- a/src/icons/strikethroughIcon.tsx
+++ b/src/icons/strikethroughIcon.tsx
@@ -32,3 +32,4 @@ export const StrikethroughIcon = forwardRef(function StrikethroughIcon(
     </svg>
   )
 })
+StrikethroughIcon.displayName = 'ForwardRef(StrikethroughIcon)'

--- a/src/icons/stringIcon.tsx
+++ b/src/icons/stringIcon.tsx
@@ -37,3 +37,4 @@ export const StringIcon = forwardRef(function StringIcon(
     </svg>
   )
 })
+StringIcon.displayName = 'ForwardRef(StringIcon)'

--- a/src/icons/sunIcon.tsx
+++ b/src/icons/sunIcon.tsx
@@ -29,3 +29,4 @@ export const SunIcon = forwardRef(function SunIcon(
     </svg>
   )
 })
+SunIcon.displayName = 'ForwardRef(SunIcon)'

--- a/src/icons/syncIcon.tsx
+++ b/src/icons/syncIcon.tsx
@@ -35,3 +35,4 @@ export const SyncIcon = forwardRef(function SyncIcon(
     </svg>
   )
 })
+SyncIcon.displayName = 'ForwardRef(SyncIcon)'

--- a/src/icons/tabletDeviceIcon.tsx
+++ b/src/icons/tabletDeviceIcon.tsx
@@ -35,3 +35,4 @@ export const TabletDeviceIcon = forwardRef(function TabletDeviceIcon(
     </svg>
   )
 })
+TabletDeviceIcon.displayName = 'ForwardRef(TabletDeviceIcon)'

--- a/src/icons/tagIcon.tsx
+++ b/src/icons/tagIcon.tsx
@@ -35,3 +35,4 @@ export const TagIcon = forwardRef(function TagIcon(
     </svg>
   )
 })
+TagIcon.displayName = 'ForwardRef(TagIcon)'

--- a/src/icons/tagsIcon.tsx
+++ b/src/icons/tagsIcon.tsx
@@ -29,3 +29,4 @@ export const TagsIcon = forwardRef(function TagsIcon(
     </svg>
   )
 })
+TagsIcon.displayName = 'ForwardRef(TagsIcon)'

--- a/src/icons/taskIcon.tsx
+++ b/src/icons/taskIcon.tsx
@@ -35,3 +35,4 @@ export const TaskIcon = forwardRef(function TaskIcon(
     </svg>
   )
 })
+TaskIcon.displayName = 'ForwardRef(TaskIcon)'

--- a/src/icons/terminalIcon.tsx
+++ b/src/icons/terminalIcon.tsx
@@ -29,3 +29,4 @@ export const TerminalIcon = forwardRef(function TerminalIcon(
     </svg>
   )
 })
+TerminalIcon.displayName = 'ForwardRef(TerminalIcon)'

--- a/src/icons/textIcon.tsx
+++ b/src/icons/textIcon.tsx
@@ -29,3 +29,4 @@ export const TextIcon = forwardRef(function TextIcon(
     </svg>
   )
 })
+TextIcon.displayName = 'ForwardRef(TextIcon)'

--- a/src/icons/thLargeIcon.tsx
+++ b/src/icons/thLargeIcon.tsx
@@ -29,3 +29,4 @@ export const ThLargeIcon = forwardRef(function ThLargeIcon(
     </svg>
   )
 })
+ThLargeIcon.displayName = 'ForwardRef(ThLargeIcon)'

--- a/src/icons/thListIcon.tsx
+++ b/src/icons/thListIcon.tsx
@@ -29,3 +29,4 @@ export const ThListIcon = forwardRef(function ThListIcon(
     </svg>
   )
 })
+ThListIcon.displayName = 'ForwardRef(ThListIcon)'

--- a/src/icons/tiersIcon.tsx
+++ b/src/icons/tiersIcon.tsx
@@ -29,3 +29,4 @@ export const TiersIcon = forwardRef(function TiersIcon(
     </svg>
   )
 })
+TiersIcon.displayName = 'ForwardRef(TiersIcon)'

--- a/src/icons/toggleArrowRightIcon.tsx
+++ b/src/icons/toggleArrowRightIcon.tsx
@@ -29,3 +29,4 @@ export const ToggleArrowRightIcon = forwardRef(function ToggleArrowRightIcon(
     </svg>
   )
 })
+ToggleArrowRightIcon.displayName = 'ForwardRef(ToggleArrowRightIcon)'

--- a/src/icons/tokenIcon.tsx
+++ b/src/icons/tokenIcon.tsx
@@ -29,3 +29,4 @@ export const TokenIcon = forwardRef(function TokenIcon(
     </svg>
   )
 })
+TokenIcon.displayName = 'ForwardRef(TokenIcon)'

--- a/src/icons/transferIcon.tsx
+++ b/src/icons/transferIcon.tsx
@@ -35,3 +35,4 @@ export const TransferIcon = forwardRef(function TransferIcon(
     </svg>
   )
 })
+TransferIcon.displayName = 'ForwardRef(TransferIcon)'

--- a/src/icons/translateIcon.tsx
+++ b/src/icons/translateIcon.tsx
@@ -29,3 +29,4 @@ export const TranslateIcon = forwardRef(function TranslateIcon(
     </svg>
   )
 })
+TranslateIcon.displayName = 'ForwardRef(TranslateIcon)'

--- a/src/icons/trashIcon.tsx
+++ b/src/icons/trashIcon.tsx
@@ -29,3 +29,4 @@ export const TrashIcon = forwardRef(function TrashIcon(
     </svg>
   )
 })
+TrashIcon.displayName = 'ForwardRef(TrashIcon)'

--- a/src/icons/trendUpwardIcon.tsx
+++ b/src/icons/trendUpwardIcon.tsx
@@ -30,3 +30,4 @@ export const TrendUpwardIcon = forwardRef(function TrendUpwardIcon(
     </svg>
   )
 })
+TrendUpwardIcon.displayName = 'ForwardRef(TrendUpwardIcon)'

--- a/src/icons/triangleOutlineIcon.tsx
+++ b/src/icons/triangleOutlineIcon.tsx
@@ -29,3 +29,4 @@ export const TriangleOutlineIcon = forwardRef(function TriangleOutlineIcon(
     </svg>
   )
 })
+TriangleOutlineIcon.displayName = 'ForwardRef(TriangleOutlineIcon)'

--- a/src/icons/trolleyIcon.tsx
+++ b/src/icons/trolleyIcon.tsx
@@ -29,3 +29,4 @@ export const TrolleyIcon = forwardRef(function TrolleyIcon(
     </svg>
   )
 })
+TrolleyIcon.displayName = 'ForwardRef(TrolleyIcon)'

--- a/src/icons/truncateIcon.tsx
+++ b/src/icons/truncateIcon.tsx
@@ -29,3 +29,4 @@ export const TruncateIcon = forwardRef(function TruncateIcon(
     </svg>
   )
 })
+TruncateIcon.displayName = 'ForwardRef(TruncateIcon)'

--- a/src/icons/twitterIcon.tsx
+++ b/src/icons/twitterIcon.tsx
@@ -27,3 +27,4 @@ export const TwitterIcon = forwardRef(function TwitterIcon(
     </svg>
   )
 })
+TwitterIcon.displayName = 'ForwardRef(TwitterIcon)'

--- a/src/icons/ulistIcon.tsx
+++ b/src/icons/ulistIcon.tsx
@@ -47,3 +47,4 @@ export const UlistIcon = forwardRef(function UlistIcon(
     </svg>
   )
 })
+UlistIcon.displayName = 'ForwardRef(UlistIcon)'

--- a/src/icons/unarchiveIcon.tsx
+++ b/src/icons/unarchiveIcon.tsx
@@ -35,3 +35,4 @@ export const UnarchiveIcon = forwardRef(function UnarchiveIcon(
     </svg>
   )
 })
+UnarchiveIcon.displayName = 'ForwardRef(UnarchiveIcon)'

--- a/src/icons/underlineIcon.tsx
+++ b/src/icons/underlineIcon.tsx
@@ -28,3 +28,4 @@ export const UnderlineIcon = forwardRef(function UnderlineIcon(
     </svg>
   )
 })
+UnderlineIcon.displayName = 'ForwardRef(UnderlineIcon)'

--- a/src/icons/undoIcon.tsx
+++ b/src/icons/undoIcon.tsx
@@ -35,3 +35,4 @@ export const UndoIcon = forwardRef(function UndoIcon(
     </svg>
   )
 })
+UndoIcon.displayName = 'ForwardRef(UndoIcon)'

--- a/src/icons/unknownIcon.tsx
+++ b/src/icons/unknownIcon.tsx
@@ -29,3 +29,4 @@ export const UnknownIcon = forwardRef(function UnknownIcon(
     </svg>
   )
 })
+UnknownIcon.displayName = 'ForwardRef(UnknownIcon)'

--- a/src/icons/unlinkIcon.tsx
+++ b/src/icons/unlinkIcon.tsx
@@ -29,3 +29,4 @@ export const UnlinkIcon = forwardRef(function UnlinkIcon(
     </svg>
   )
 })
+UnlinkIcon.displayName = 'ForwardRef(UnlinkIcon)'

--- a/src/icons/unlockIcon.tsx
+++ b/src/icons/unlockIcon.tsx
@@ -29,3 +29,4 @@ export const UnlockIcon = forwardRef(function UnlockIcon(
     </svg>
   )
 })
+UnlockIcon.displayName = 'ForwardRef(UnlockIcon)'

--- a/src/icons/unpublishIcon.tsx
+++ b/src/icons/unpublishIcon.tsx
@@ -35,3 +35,4 @@ export const UnpublishIcon = forwardRef(function UnpublishIcon(
     </svg>
   )
 })
+UnpublishIcon.displayName = 'ForwardRef(UnpublishIcon)'

--- a/src/icons/uploadIcon.tsx
+++ b/src/icons/uploadIcon.tsx
@@ -35,3 +35,4 @@ export const UploadIcon = forwardRef(function UploadIcon(
     </svg>
   )
 })
+UploadIcon.displayName = 'ForwardRef(UploadIcon)'

--- a/src/icons/userIcon.tsx
+++ b/src/icons/userIcon.tsx
@@ -29,3 +29,4 @@ export const UserIcon = forwardRef(function UserIcon(
     </svg>
   )
 })
+UserIcon.displayName = 'ForwardRef(UserIcon)'

--- a/src/icons/usersIcon.tsx
+++ b/src/icons/usersIcon.tsx
@@ -29,3 +29,4 @@ export const UsersIcon = forwardRef(function UsersIcon(
     </svg>
   )
 })
+UsersIcon.displayName = 'ForwardRef(UsersIcon)'

--- a/src/icons/warningFilledIcon.tsx
+++ b/src/icons/warningFilledIcon.tsx
@@ -29,3 +29,4 @@ export const WarningFilledIcon = forwardRef(function WarningFilledIcon(
     </svg>
   )
 })
+WarningFilledIcon.displayName = 'ForwardRef(WarningFilledIcon)'

--- a/src/icons/warningOutlineIcon.tsx
+++ b/src/icons/warningOutlineIcon.tsx
@@ -29,3 +29,4 @@ export const WarningOutlineIcon = forwardRef(function WarningOutlineIcon(
     </svg>
   )
 })
+WarningOutlineIcon.displayName = 'ForwardRef(WarningOutlineIcon)'

--- a/src/icons/wrenchIcon.tsx
+++ b/src/icons/wrenchIcon.tsx
@@ -27,3 +27,4 @@ export const WrenchIcon = forwardRef(function WrenchIcon(
     </svg>
   )
 })
+WrenchIcon.displayName = 'ForwardRef(WrenchIcon)'


### PR DESCRIPTION
Currently our icons show up as `Anonymous` when inspected in the React DevTools on builds that minify the output, like [here](https://icons.sanity.build/frame/?path=%2Fall&scheme=dark&viewport=auto&zoom=1):
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/480fa5cd-efcf-488f-a5a0-1de01124e0c3">

By adding `displayName` we ensure that no matter what kind of bundling is used you can [still see the icon name](https://icons-git-add-display-name.sanity.dev/frame/?path=%2Fall&scheme=dark&viewport=auto&zoom=1):
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/cc6e9bf5-2eb9-4bb0-8e5e-42ff71871e4b">

Wrapping then name like this `Icon.displayName = 'ForwardRef(Icon)'` instead of just `Icon.displayName = 'Icon'` [is how React renders the little `ForwardRef` label next to the name. ](https://github.com/facebook/react/blob/66df94460e27ff382c07b13d0bcc4b2778bfc201/packages/shared/getComponentNameFromType.js#L122).