### PR TITLE
fix: fully support rollup treeshaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/icons",
-  "version": "3.7.4-canary.0",
+  "version": "3.7.4-canary.4",
   "description": "The Sanity icons.",
   "keywords": [
     "sanity",

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -24,12 +24,11 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const __NAME__: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>
-> = forwardRef(function __NAME__(props, ref) {
+> = /* @__PURE__ */ forwardRef(function __NAME__(props, ref) {
   return (
     __JSX__
   )
 });
-__NAME__.displayName = 'ForwardRef(__NAME__)'
 `
 
 async function readIcon(filePath: string) {
@@ -139,6 +138,12 @@ async function generate() {
     .map((f) => `'${f.name}': ${f.componentName}`)
     .join(',')}}`
 
+  // const getIconsMap = `const getIcons: () => IconMap = () => ({${files
+  //   .map((f) => `'${f.name}': ${f.componentName}`)
+  //   .join(',')}})`
+
+  // const iconsExport = `/**\n * @public\n */\nexport const icons: IconMap = /* @__PURE__ */ getIcons();`
+
   const indexPath = path.resolve(SRC_ICONS_PATH, `index.ts`)
 
   const indexTsCode = await format(
@@ -149,6 +154,7 @@ async function generate() {
       typesExports,
       iconExports,
       iconMapInterface,
+      // getIconsMap,
       iconsExport,
     ].join('\n\n'),
     {

--- a/src/icon.tsx
+++ b/src/icon.tsx
@@ -14,7 +14,7 @@ export interface IconProps {
  */
 export const Icon: ForwardRefExoticComponent<
   IconProps & Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function Icon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function Icon(props, ref) {
   const {symbol, ...restProps} = props
   const IconComponent = icons[symbol]
 
@@ -24,4 +24,3 @@ export const Icon: ForwardRefExoticComponent<
 
   return <IconComponent {...restProps} ref={ref} />
 })
-Icon.displayName = 'ForwardRef(Icon)'

--- a/src/icons/accessDeniedIcon.tsx
+++ b/src/icons/accessDeniedIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const AccessDeniedIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function AccessDeniedIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function AccessDeniedIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="access-denied"
@@ -28,4 +28,3 @@ export const AccessDeniedIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-AccessDeniedIcon.displayName = 'ForwardRef(AccessDeniedIcon)'

--- a/src/icons/activityIcon.tsx
+++ b/src/icons/activityIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ActivityIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ActivityIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ActivityIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="activity"
@@ -28,4 +28,3 @@ export const ActivityIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ActivityIcon.displayName = 'ForwardRef(ActivityIcon)'

--- a/src/icons/addCircleIcon.tsx
+++ b/src/icons/addCircleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const AddCircleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function AddCircleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function AddCircleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="add-circle"
@@ -28,4 +28,3 @@ export const AddCircleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-AddCircleIcon.displayName = 'ForwardRef(AddCircleIcon)'

--- a/src/icons/addCommentIcon.tsx
+++ b/src/icons/addCommentIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const AddCommentIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function AddCommentIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function AddCommentIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="add-comment"
@@ -28,4 +28,3 @@ export const AddCommentIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-AddCommentIcon.displayName = 'ForwardRef(AddCommentIcon)'

--- a/src/icons/addDocumentIcon.tsx
+++ b/src/icons/addDocumentIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const AddDocumentIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function AddDocumentIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function AddDocumentIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="add-document"
@@ -29,4 +29,3 @@ export const AddDocumentIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-AddDocumentIcon.displayName = 'ForwardRef(AddDocumentIcon)'

--- a/src/icons/addIcon.tsx
+++ b/src/icons/addIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const AddIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function AddIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function AddIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="add"
@@ -28,4 +28,3 @@ export const AddIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-AddIcon.displayName = 'ForwardRef(AddIcon)'

--- a/src/icons/addUserIcon.tsx
+++ b/src/icons/addUserIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const AddUserIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function AddUserIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function AddUserIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="add-user"
@@ -34,4 +34,3 @@ export const AddUserIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-AddUserIcon.displayName = 'ForwardRef(AddUserIcon)'

--- a/src/icons/apiIcon.tsx
+++ b/src/icons/apiIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ApiIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ApiIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ApiIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="api"
@@ -34,4 +34,3 @@ export const ApiIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ApiIcon.displayName = 'ForwardRef(ApiIcon)'

--- a/src/icons/archiveIcon.tsx
+++ b/src/icons/archiveIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ArchiveIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ArchiveIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ArchiveIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="archive"
@@ -34,4 +34,3 @@ export const ArchiveIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ArchiveIcon.displayName = 'ForwardRef(ArchiveIcon)'

--- a/src/icons/arrowDownIcon.tsx
+++ b/src/icons/arrowDownIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ArrowDownIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ArrowDownIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ArrowDownIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="arrow-down"
@@ -29,4 +29,3 @@ export const ArrowDownIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ArrowDownIcon.displayName = 'ForwardRef(ArrowDownIcon)'

--- a/src/icons/arrowLeftIcon.tsx
+++ b/src/icons/arrowLeftIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ArrowLeftIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ArrowLeftIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ArrowLeftIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="arrow-left"
@@ -29,4 +29,3 @@ export const ArrowLeftIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ArrowLeftIcon.displayName = 'ForwardRef(ArrowLeftIcon)'

--- a/src/icons/arrowRightIcon.tsx
+++ b/src/icons/arrowRightIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ArrowRightIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ArrowRightIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ArrowRightIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="arrow-right"
@@ -29,4 +29,3 @@ export const ArrowRightIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ArrowRightIcon.displayName = 'ForwardRef(ArrowRightIcon)'

--- a/src/icons/arrowTopRightIcon.tsx
+++ b/src/icons/arrowTopRightIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ArrowTopRightIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ArrowTopRightIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ArrowTopRightIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="arrow-top-right"
@@ -24,4 +24,3 @@ export const ArrowTopRightIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ArrowTopRightIcon.displayName = 'ForwardRef(ArrowTopRightIcon)'

--- a/src/icons/arrowUpIcon.tsx
+++ b/src/icons/arrowUpIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ArrowUpIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ArrowUpIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ArrowUpIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="arrow-up"
@@ -29,4 +29,3 @@ export const ArrowUpIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ArrowUpIcon.displayName = 'ForwardRef(ArrowUpIcon)'

--- a/src/icons/asteriskIcon.tsx
+++ b/src/icons/asteriskIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const AsteriskIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function AsteriskIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function AsteriskIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="asterisk"
@@ -28,4 +28,3 @@ export const AsteriskIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-AsteriskIcon.displayName = 'ForwardRef(AsteriskIcon)'

--- a/src/icons/barChartIcon.tsx
+++ b/src/icons/barChartIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BarChartIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BarChartIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BarChartIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bar-chart"
@@ -28,4 +28,3 @@ export const BarChartIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BarChartIcon.displayName = 'ForwardRef(BarChartIcon)'

--- a/src/icons/basketIcon.tsx
+++ b/src/icons/basketIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BasketIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BasketIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BasketIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="basket"
@@ -28,4 +28,3 @@ export const BasketIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BasketIcon.displayName = 'ForwardRef(BasketIcon)'

--- a/src/icons/bellIcon.tsx
+++ b/src/icons/bellIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BellIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BellIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BellIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bell"
@@ -28,4 +28,3 @@ export const BellIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BellIcon.displayName = 'ForwardRef(BellIcon)'

--- a/src/icons/billIcon.tsx
+++ b/src/icons/billIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BillIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BillIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BillIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bill"
@@ -28,4 +28,3 @@ export const BillIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BillIcon.displayName = 'ForwardRef(BillIcon)'

--- a/src/icons/binaryDocumentIcon.tsx
+++ b/src/icons/binaryDocumentIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BinaryDocumentIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BinaryDocumentIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BinaryDocumentIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="binary-document"
@@ -30,4 +30,3 @@ export const BinaryDocumentIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BinaryDocumentIcon.displayName = 'ForwardRef(BinaryDocumentIcon)'

--- a/src/icons/blockContentIcon.tsx
+++ b/src/icons/blockContentIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BlockContentIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BlockContentIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BlockContentIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="block-content"
@@ -50,4 +50,3 @@ export const BlockContentIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BlockContentIcon.displayName = 'ForwardRef(BlockContentIcon)'

--- a/src/icons/blockElementIcon.tsx
+++ b/src/icons/blockElementIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BlockElementIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BlockElementIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BlockElementIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="block-element"
@@ -28,4 +28,3 @@ export const BlockElementIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BlockElementIcon.displayName = 'ForwardRef(BlockElementIcon)'

--- a/src/icons/blockquoteIcon.tsx
+++ b/src/icons/blockquoteIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BlockquoteIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BlockquoteIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BlockquoteIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="blockquote"
@@ -28,4 +28,3 @@ export const BlockquoteIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BlockquoteIcon.displayName = 'ForwardRef(BlockquoteIcon)'

--- a/src/icons/boldIcon.tsx
+++ b/src/icons/boldIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BoldIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BoldIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BoldIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bold"
@@ -26,4 +26,3 @@ export const BoldIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BoldIcon.displayName = 'ForwardRef(BoldIcon)'

--- a/src/icons/boltIcon.tsx
+++ b/src/icons/boltIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BoltIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BoltIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BoltIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bolt"
@@ -28,4 +28,3 @@ export const BoltIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BoltIcon.displayName = 'ForwardRef(BoltIcon)'

--- a/src/icons/bookIcon.tsx
+++ b/src/icons/bookIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BookIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BookIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BookIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="book"
@@ -28,4 +28,3 @@ export const BookIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BookIcon.displayName = 'ForwardRef(BookIcon)'

--- a/src/icons/bookmarkFilledIcon.tsx
+++ b/src/icons/bookmarkFilledIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BookmarkFilledIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BookmarkFilledIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BookmarkFilledIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bookmark-filled"
@@ -29,4 +29,3 @@ export const BookmarkFilledIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BookmarkFilledIcon.displayName = 'ForwardRef(BookmarkFilledIcon)'

--- a/src/icons/bookmarkIcon.tsx
+++ b/src/icons/bookmarkIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BookmarkIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BookmarkIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BookmarkIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bookmark"
@@ -28,4 +28,3 @@ export const BookmarkIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BookmarkIcon.displayName = 'ForwardRef(BookmarkIcon)'

--- a/src/icons/bottleIcon.tsx
+++ b/src/icons/bottleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BottleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BottleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BottleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bottle"
@@ -28,4 +28,3 @@ export const BottleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BottleIcon.displayName = 'ForwardRef(BottleIcon)'

--- a/src/icons/bugIcon.tsx
+++ b/src/icons/bugIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BugIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BugIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BugIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bug"
@@ -26,4 +26,3 @@ export const BugIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BugIcon.displayName = 'ForwardRef(BugIcon)'

--- a/src/icons/bulbFilledIcon.tsx
+++ b/src/icons/bulbFilledIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BulbFilledIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BulbFilledIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BulbFilledIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bulb-filled"
@@ -28,4 +28,3 @@ export const BulbFilledIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BulbFilledIcon.displayName = 'ForwardRef(BulbFilledIcon)'

--- a/src/icons/bulbOutlineIcon.tsx
+++ b/src/icons/bulbOutlineIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const BulbOutlineIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function BulbOutlineIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function BulbOutlineIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="bulb-outline"
@@ -27,4 +27,3 @@ export const BulbOutlineIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-BulbOutlineIcon.displayName = 'ForwardRef(BulbOutlineIcon)'

--- a/src/icons/calendarIcon.tsx
+++ b/src/icons/calendarIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CalendarIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CalendarIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CalendarIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="calendar"
@@ -34,4 +34,3 @@ export const CalendarIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CalendarIcon.displayName = 'ForwardRef(CalendarIcon)'

--- a/src/icons/caseIcon.tsx
+++ b/src/icons/caseIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CaseIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CaseIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CaseIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="case"
@@ -28,4 +28,3 @@ export const CaseIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CaseIcon.displayName = 'ForwardRef(CaseIcon)'

--- a/src/icons/chartUpwardIcon.tsx
+++ b/src/icons/chartUpwardIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ChartUpwardIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ChartUpwardIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ChartUpwardIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="chart-upward"
@@ -28,4 +28,3 @@ export const ChartUpwardIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ChartUpwardIcon.displayName = 'ForwardRef(ChartUpwardIcon)'

--- a/src/icons/checkmarkCircleIcon.tsx
+++ b/src/icons/checkmarkCircleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CheckmarkCircleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CheckmarkCircleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CheckmarkCircleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="checkmark-circle"
@@ -28,4 +28,3 @@ export const CheckmarkCircleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CheckmarkCircleIcon.displayName = 'ForwardRef(CheckmarkCircleIcon)'

--- a/src/icons/checkmarkIcon.tsx
+++ b/src/icons/checkmarkIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CheckmarkIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CheckmarkIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CheckmarkIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="checkmark"
@@ -28,4 +28,3 @@ export const CheckmarkIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CheckmarkIcon.displayName = 'ForwardRef(CheckmarkIcon)'

--- a/src/icons/chevronDownIcon.tsx
+++ b/src/icons/chevronDownIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ChevronDownIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ChevronDownIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ChevronDownIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="chevron-down"
@@ -28,4 +28,3 @@ export const ChevronDownIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ChevronDownIcon.displayName = 'ForwardRef(ChevronDownIcon)'

--- a/src/icons/chevronLeftIcon.tsx
+++ b/src/icons/chevronLeftIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ChevronLeftIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ChevronLeftIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ChevronLeftIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="chevron-left"
@@ -28,4 +28,3 @@ export const ChevronLeftIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ChevronLeftIcon.displayName = 'ForwardRef(ChevronLeftIcon)'

--- a/src/icons/chevronRightIcon.tsx
+++ b/src/icons/chevronRightIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ChevronRightIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ChevronRightIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ChevronRightIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="chevron-right"
@@ -28,4 +28,3 @@ export const ChevronRightIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ChevronRightIcon.displayName = 'ForwardRef(ChevronRightIcon)'

--- a/src/icons/chevronUpIcon.tsx
+++ b/src/icons/chevronUpIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ChevronUpIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ChevronUpIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ChevronUpIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="chevron-up"
@@ -28,4 +28,3 @@ export const ChevronUpIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ChevronUpIcon.displayName = 'ForwardRef(ChevronUpIcon)'

--- a/src/icons/circleIcon.tsx
+++ b/src/icons/circleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CircleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CircleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CircleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="circle"
@@ -30,4 +30,3 @@ export const CircleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CircleIcon.displayName = 'ForwardRef(CircleIcon)'

--- a/src/icons/clipboardIcon.tsx
+++ b/src/icons/clipboardIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ClipboardIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ClipboardIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ClipboardIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="clipboard"
@@ -28,4 +28,3 @@ export const ClipboardIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ClipboardIcon.displayName = 'ForwardRef(ClipboardIcon)'

--- a/src/icons/clipboardImageIcon.tsx
+++ b/src/icons/clipboardImageIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ClipboardImageIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ClipboardImageIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ClipboardImageIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="clipboard-image"
@@ -28,4 +28,3 @@ export const ClipboardImageIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ClipboardImageIcon.displayName = 'ForwardRef(ClipboardImageIcon)'

--- a/src/icons/clockIcon.tsx
+++ b/src/icons/clockIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ClockIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ClockIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ClockIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="clock"
@@ -28,4 +28,3 @@ export const ClockIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ClockIcon.displayName = 'ForwardRef(ClockIcon)'

--- a/src/icons/closeCircleIcon.tsx
+++ b/src/icons/closeCircleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CloseCircleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CloseCircleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CloseCircleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="close-circle"
@@ -28,4 +28,3 @@ export const CloseCircleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CloseCircleIcon.displayName = 'ForwardRef(CloseCircleIcon)'

--- a/src/icons/closeIcon.tsx
+++ b/src/icons/closeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CloseIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CloseIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CloseIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="close"
@@ -28,4 +28,3 @@ export const CloseIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CloseIcon.displayName = 'ForwardRef(CloseIcon)'

--- a/src/icons/codeBlockIcon.tsx
+++ b/src/icons/codeBlockIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CodeBlockIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CodeBlockIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CodeBlockIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="code-block"
@@ -28,4 +28,3 @@ export const CodeBlockIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CodeBlockIcon.displayName = 'ForwardRef(CodeBlockIcon)'

--- a/src/icons/codeIcon.tsx
+++ b/src/icons/codeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CodeIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CodeIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CodeIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="code"
@@ -28,4 +28,3 @@ export const CodeIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CodeIcon.displayName = 'ForwardRef(CodeIcon)'

--- a/src/icons/cogIcon.tsx
+++ b/src/icons/cogIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CogIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CogIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CogIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="cog"
@@ -34,4 +34,3 @@ export const CogIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CogIcon.displayName = 'ForwardRef(CogIcon)'

--- a/src/icons/collapseIcon.tsx
+++ b/src/icons/collapseIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CollapseIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CollapseIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CollapseIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="collapse"
@@ -34,4 +34,3 @@ export const CollapseIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CollapseIcon.displayName = 'ForwardRef(CollapseIcon)'

--- a/src/icons/colorWheelIcon.tsx
+++ b/src/icons/colorWheelIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ColorWheelIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ColorWheelIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ColorWheelIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="color-wheel"
@@ -28,4 +28,3 @@ export const ColorWheelIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ColorWheelIcon.displayName = 'ForwardRef(ColorWheelIcon)'

--- a/src/icons/commentIcon.tsx
+++ b/src/icons/commentIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CommentIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CommentIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CommentIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="comment"
@@ -28,4 +28,3 @@ export const CommentIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CommentIcon.displayName = 'ForwardRef(CommentIcon)'

--- a/src/icons/componentIcon.tsx
+++ b/src/icons/componentIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ComponentIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ComponentIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ComponentIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="component"
@@ -28,4 +28,3 @@ export const ComponentIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ComponentIcon.displayName = 'ForwardRef(ComponentIcon)'

--- a/src/icons/composeIcon.tsx
+++ b/src/icons/composeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ComposeIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ComposeIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ComposeIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="compose"
@@ -28,4 +28,3 @@ export const ComposeIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ComposeIcon.displayName = 'ForwardRef(ComposeIcon)'

--- a/src/icons/composeSparklesIcon.tsx
+++ b/src/icons/composeSparklesIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ComposeSparklesIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ComposeSparklesIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ComposeSparklesIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="compose-sparkles"
@@ -29,4 +29,3 @@ export const ComposeSparklesIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ComposeSparklesIcon.displayName = 'ForwardRef(ComposeSparklesIcon)'

--- a/src/icons/confettiIcon.tsx
+++ b/src/icons/confettiIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ConfettiIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ConfettiIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ConfettiIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="confetti"
@@ -42,4 +42,3 @@ export const ConfettiIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ConfettiIcon.displayName = 'ForwardRef(ConfettiIcon)'

--- a/src/icons/controlsIcon.tsx
+++ b/src/icons/controlsIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ControlsIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ControlsIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ControlsIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="controls"
@@ -28,4 +28,3 @@ export const ControlsIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ControlsIcon.displayName = 'ForwardRef(ControlsIcon)'

--- a/src/icons/copyIcon.tsx
+++ b/src/icons/copyIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CopyIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CopyIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CopyIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="copy"
@@ -28,4 +28,3 @@ export const CopyIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CopyIcon.displayName = 'ForwardRef(CopyIcon)'

--- a/src/icons/creditCardIcon.tsx
+++ b/src/icons/creditCardIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CreditCardIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CreditCardIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CreditCardIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="credit-card"
@@ -35,4 +35,3 @@ export const CreditCardIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CreditCardIcon.displayName = 'ForwardRef(CreditCardIcon)'

--- a/src/icons/cropIcon.tsx
+++ b/src/icons/cropIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CropIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CropIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CropIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="crop"
@@ -28,4 +28,3 @@ export const CropIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CropIcon.displayName = 'ForwardRef(CropIcon)'

--- a/src/icons/cubeIcon.tsx
+++ b/src/icons/cubeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const CubeIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function CubeIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function CubeIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="cube"
@@ -34,4 +34,3 @@ export const CubeIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-CubeIcon.displayName = 'ForwardRef(CubeIcon)'

--- a/src/icons/dashboardIcon.tsx
+++ b/src/icons/dashboardIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DashboardIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DashboardIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DashboardIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="dashboard"
@@ -28,4 +28,3 @@ export const DashboardIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DashboardIcon.displayName = 'ForwardRef(DashboardIcon)'

--- a/src/icons/databaseIcon.tsx
+++ b/src/icons/databaseIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DatabaseIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DatabaseIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DatabaseIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="database"
@@ -28,4 +28,3 @@ export const DatabaseIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DatabaseIcon.displayName = 'ForwardRef(DatabaseIcon)'

--- a/src/icons/desktopIcon.tsx
+++ b/src/icons/desktopIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DesktopIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DesktopIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DesktopIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="desktop"
@@ -28,4 +28,3 @@ export const DesktopIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DesktopIcon.displayName = 'ForwardRef(DesktopIcon)'

--- a/src/icons/diamondIcon.tsx
+++ b/src/icons/diamondIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DiamondIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DiamondIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DiamondIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="diamond"
@@ -28,4 +28,3 @@ export const DiamondIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DiamondIcon.displayName = 'ForwardRef(DiamondIcon)'

--- a/src/icons/documentIcon.tsx
+++ b/src/icons/documentIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="document"
@@ -29,4 +29,3 @@ export const DocumentIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentIcon.displayName = 'ForwardRef(DocumentIcon)'

--- a/src/icons/documentPdfIcon.tsx
+++ b/src/icons/documentPdfIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentPdfIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentPdfIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentPdfIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="document-pdf"
@@ -33,4 +33,3 @@ export const DocumentPdfIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentPdfIcon.displayName = 'ForwardRef(DocumentPdfIcon)'

--- a/src/icons/documentRemoveIcon.tsx
+++ b/src/icons/documentRemoveIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentRemoveIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentRemoveIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentRemoveIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="document-remove"
@@ -29,4 +29,3 @@ export const DocumentRemoveIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentRemoveIcon.displayName = 'ForwardRef(DocumentRemoveIcon)'

--- a/src/icons/documentSheetIcon.tsx
+++ b/src/icons/documentSheetIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentSheetIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentSheetIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentSheetIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="document-sheet"
@@ -29,4 +29,3 @@ export const DocumentSheetIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentSheetIcon.displayName = 'ForwardRef(DocumentSheetIcon)'

--- a/src/icons/documentTextIcon.tsx
+++ b/src/icons/documentTextIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentTextIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentTextIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentTextIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="document-text"
@@ -29,4 +29,3 @@ export const DocumentTextIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentTextIcon.displayName = 'ForwardRef(DocumentTextIcon)'

--- a/src/icons/documentVideoIcon.tsx
+++ b/src/icons/documentVideoIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentVideoIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentVideoIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentVideoIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="document-video"
@@ -35,4 +35,3 @@ export const DocumentVideoIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentVideoIcon.displayName = 'ForwardRef(DocumentVideoIcon)'

--- a/src/icons/documentWordIcon.tsx
+++ b/src/icons/documentWordIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentWordIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentWordIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentWordIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="document-word"
@@ -33,4 +33,3 @@ export const DocumentWordIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentWordIcon.displayName = 'ForwardRef(DocumentWordIcon)'

--- a/src/icons/documentZipIcon.tsx
+++ b/src/icons/documentZipIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentZipIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentZipIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentZipIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="document-zip"
@@ -29,4 +29,3 @@ export const DocumentZipIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentZipIcon.displayName = 'ForwardRef(DocumentZipIcon)'

--- a/src/icons/documentsIcon.tsx
+++ b/src/icons/documentsIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DocumentsIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DocumentsIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DocumentsIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="documents"
@@ -29,4 +29,3 @@ export const DocumentsIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DocumentsIcon.displayName = 'ForwardRef(DocumentsIcon)'

--- a/src/icons/dotIcon.tsx
+++ b/src/icons/dotIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DotIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DotIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DotIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="dot"
@@ -30,4 +30,3 @@ export const DotIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DotIcon.displayName = 'ForwardRef(DotIcon)'

--- a/src/icons/doubleChevronDownIcon.tsx
+++ b/src/icons/doubleChevronDownIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DoubleChevronDownIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DoubleChevronDownIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DoubleChevronDownIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="double-chevron-down"
@@ -28,4 +28,3 @@ export const DoubleChevronDownIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DoubleChevronDownIcon.displayName = 'ForwardRef(DoubleChevronDownIcon)'

--- a/src/icons/doubleChevronLeftIcon.tsx
+++ b/src/icons/doubleChevronLeftIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DoubleChevronLeftIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DoubleChevronLeftIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DoubleChevronLeftIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="double-chevron-left"
@@ -28,4 +28,3 @@ export const DoubleChevronLeftIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DoubleChevronLeftIcon.displayName = 'ForwardRef(DoubleChevronLeftIcon)'

--- a/src/icons/doubleChevronRightIcon.tsx
+++ b/src/icons/doubleChevronRightIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DoubleChevronRightIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DoubleChevronRightIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DoubleChevronRightIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="double-chevron-right"
@@ -28,4 +28,3 @@ export const DoubleChevronRightIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DoubleChevronRightIcon.displayName = 'ForwardRef(DoubleChevronRightIcon)'

--- a/src/icons/doubleChevronUpIcon.tsx
+++ b/src/icons/doubleChevronUpIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DoubleChevronUpIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DoubleChevronUpIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DoubleChevronUpIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="double-chevron-up"
@@ -28,4 +28,3 @@ export const DoubleChevronUpIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DoubleChevronUpIcon.displayName = 'ForwardRef(DoubleChevronUpIcon)'

--- a/src/icons/downloadIcon.tsx
+++ b/src/icons/downloadIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DownloadIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DownloadIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DownloadIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="download"
@@ -34,4 +34,3 @@ export const DownloadIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DownloadIcon.displayName = 'ForwardRef(DownloadIcon)'

--- a/src/icons/dragHandleIcon.tsx
+++ b/src/icons/dragHandleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DragHandleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DragHandleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DragHandleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="drag-handle"
@@ -46,4 +46,3 @@ export const DragHandleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DragHandleIcon.displayName = 'ForwardRef(DragHandleIcon)'

--- a/src/icons/dropIcon.tsx
+++ b/src/icons/dropIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const DropIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function DropIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function DropIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="drop"
@@ -28,4 +28,3 @@ export const DropIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-DropIcon.displayName = 'ForwardRef(DropIcon)'

--- a/src/icons/earthAmericasIcon.tsx
+++ b/src/icons/earthAmericasIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EarthAmericasIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EarthAmericasIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EarthAmericasIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="earth-americas"
@@ -37,4 +37,3 @@ export const EarthAmericasIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EarthAmericasIcon.displayName = 'ForwardRef(EarthAmericasIcon)'

--- a/src/icons/earthGlobeIcon.tsx
+++ b/src/icons/earthGlobeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EarthGlobeIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EarthGlobeIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EarthGlobeIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="earth-globe"
@@ -34,4 +34,3 @@ export const EarthGlobeIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EarthGlobeIcon.displayName = 'ForwardRef(EarthGlobeIcon)'

--- a/src/icons/editIcon.tsx
+++ b/src/icons/editIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EditIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EditIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EditIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="edit"
@@ -28,4 +28,3 @@ export const EditIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EditIcon.displayName = 'ForwardRef(EditIcon)'

--- a/src/icons/ellipsisHorizontalIcon.tsx
+++ b/src/icons/ellipsisHorizontalIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EllipsisHorizontalIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EllipsisHorizontalIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EllipsisHorizontalIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="ellipsis-horizontal"
@@ -34,4 +34,3 @@ export const EllipsisHorizontalIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EllipsisHorizontalIcon.displayName = 'ForwardRef(EllipsisHorizontalIcon)'

--- a/src/icons/ellipsisVerticalIcon.tsx
+++ b/src/icons/ellipsisVerticalIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EllipsisVerticalIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EllipsisVerticalIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EllipsisVerticalIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="ellipsis-vertical"
@@ -34,4 +34,3 @@ export const EllipsisVerticalIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EllipsisVerticalIcon.displayName = 'ForwardRef(EllipsisVerticalIcon)'

--- a/src/icons/emptyIcon.tsx
+++ b/src/icons/emptyIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EmptyIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EmptyIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EmptyIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="empty"
@@ -27,4 +27,3 @@ export const EmptyIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EmptyIcon.displayName = 'ForwardRef(EmptyIcon)'

--- a/src/icons/enterIcon.tsx
+++ b/src/icons/enterIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EnterIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EnterIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EnterIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="enter"
@@ -29,4 +29,3 @@ export const EnterIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EnterIcon.displayName = 'ForwardRef(EnterIcon)'

--- a/src/icons/enterRightIcon.tsx
+++ b/src/icons/enterRightIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EnterRightIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EnterRightIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EnterRightIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="enter-right"
@@ -29,4 +29,3 @@ export const EnterRightIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EnterRightIcon.displayName = 'ForwardRef(EnterRightIcon)'

--- a/src/icons/envelopeIcon.tsx
+++ b/src/icons/envelopeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EnvelopeIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EnvelopeIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EnvelopeIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="envelope"
@@ -34,4 +34,3 @@ export const EnvelopeIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EnvelopeIcon.displayName = 'ForwardRef(EnvelopeIcon)'

--- a/src/icons/equalIcon.tsx
+++ b/src/icons/equalIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EqualIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EqualIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EqualIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="equal"
@@ -26,4 +26,3 @@ export const EqualIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EqualIcon.displayName = 'ForwardRef(EqualIcon)'

--- a/src/icons/errorFilledIcon.tsx
+++ b/src/icons/errorFilledIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ErrorFilledIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ErrorFilledIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ErrorFilledIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="error-filled"
@@ -28,4 +28,3 @@ export const ErrorFilledIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ErrorFilledIcon.displayName = 'ForwardRef(ErrorFilledIcon)'

--- a/src/icons/errorOutlineIcon.tsx
+++ b/src/icons/errorOutlineIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ErrorOutlineIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ErrorOutlineIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ErrorOutlineIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="error-outline"
@@ -28,4 +28,3 @@ export const ErrorOutlineIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ErrorOutlineIcon.displayName = 'ForwardRef(ErrorOutlineIcon)'

--- a/src/icons/errorScreenIcon.tsx
+++ b/src/icons/errorScreenIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ErrorScreenIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ErrorScreenIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ErrorScreenIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="error-screen"
@@ -34,4 +34,3 @@ export const ErrorScreenIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ErrorScreenIcon.displayName = 'ForwardRef(ErrorScreenIcon)'

--- a/src/icons/expandIcon.tsx
+++ b/src/icons/expandIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ExpandIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ExpandIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ExpandIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="expand"
@@ -34,4 +34,3 @@ export const ExpandIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ExpandIcon.displayName = 'ForwardRef(ExpandIcon)'

--- a/src/icons/eyeClosedIcon.tsx
+++ b/src/icons/eyeClosedIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EyeClosedIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EyeClosedIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EyeClosedIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="eye-closed"
@@ -28,4 +28,3 @@ export const EyeClosedIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EyeClosedIcon.displayName = 'ForwardRef(EyeClosedIcon)'

--- a/src/icons/eyeOpenIcon.tsx
+++ b/src/icons/eyeOpenIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const EyeOpenIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function EyeOpenIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function EyeOpenIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="eye-open"
@@ -34,4 +34,3 @@ export const EyeOpenIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-EyeOpenIcon.displayName = 'ForwardRef(EyeOpenIcon)'

--- a/src/icons/faceHappyIcon.tsx
+++ b/src/icons/faceHappyIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const FaceHappyIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function FaceHappyIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function FaceHappyIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="face-happy"
@@ -28,4 +28,3 @@ export const FaceHappyIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-FaceHappyIcon.displayName = 'ForwardRef(FaceHappyIcon)'

--- a/src/icons/faceIndifferentIcon.tsx
+++ b/src/icons/faceIndifferentIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const FaceIndifferentIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function FaceIndifferentIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function FaceIndifferentIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="face-indifferent"
@@ -28,4 +28,3 @@ export const FaceIndifferentIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-FaceIndifferentIcon.displayName = 'ForwardRef(FaceIndifferentIcon)'

--- a/src/icons/faceSadIcon.tsx
+++ b/src/icons/faceSadIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const FaceSadIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function FaceSadIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function FaceSadIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="face-sad"
@@ -28,4 +28,3 @@ export const FaceSadIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-FaceSadIcon.displayName = 'ForwardRef(FaceSadIcon)'

--- a/src/icons/feedbackIcon.tsx
+++ b/src/icons/feedbackIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const FeedbackIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function FeedbackIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function FeedbackIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="feedback"
@@ -49,4 +49,3 @@ export const FeedbackIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-FeedbackIcon.displayName = 'ForwardRef(FeedbackIcon)'

--- a/src/icons/filterIcon.tsx
+++ b/src/icons/filterIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const FilterIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function FilterIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function FilterIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="filter"
@@ -28,4 +28,3 @@ export const FilterIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-FilterIcon.displayName = 'ForwardRef(FilterIcon)'

--- a/src/icons/folderIcon.tsx
+++ b/src/icons/folderIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const FolderIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function FolderIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function FolderIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="folder"
@@ -28,4 +28,3 @@ export const FolderIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-FolderIcon.displayName = 'ForwardRef(FolderIcon)'

--- a/src/icons/generateIcon.tsx
+++ b/src/icons/generateIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const GenerateIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function GenerateIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function GenerateIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="generate"
@@ -34,4 +34,3 @@ export const GenerateIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-GenerateIcon.displayName = 'ForwardRef(GenerateIcon)'

--- a/src/icons/githubIcon.tsx
+++ b/src/icons/githubIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const GithubIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function GithubIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function GithubIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="github"
@@ -28,4 +28,3 @@ export const GithubIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-GithubIcon.displayName = 'ForwardRef(GithubIcon)'

--- a/src/icons/groqIcon.tsx
+++ b/src/icons/groqIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const GroqIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function GroqIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function GroqIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="groq"
@@ -25,4 +25,3 @@ export const GroqIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-GroqIcon.displayName = 'ForwardRef(GroqIcon)'

--- a/src/icons/hashIcon.tsx
+++ b/src/icons/hashIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const HashIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function HashIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function HashIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="hash"
@@ -28,4 +28,3 @@ export const HashIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-HashIcon.displayName = 'ForwardRef(HashIcon)'

--- a/src/icons/heartFilledIcon.tsx
+++ b/src/icons/heartFilledIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const HeartFilledIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function HeartFilledIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function HeartFilledIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="heart-filled"
@@ -29,4 +29,3 @@ export const HeartFilledIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-HeartFilledIcon.displayName = 'ForwardRef(HeartFilledIcon)'

--- a/src/icons/heartIcon.tsx
+++ b/src/icons/heartIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const HeartIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function HeartIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function HeartIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="heart"
@@ -28,4 +28,3 @@ export const HeartIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-HeartIcon.displayName = 'ForwardRef(HeartIcon)'

--- a/src/icons/helpCircleIcon.tsx
+++ b/src/icons/helpCircleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const HelpCircleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function HelpCircleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function HelpCircleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="help-circle"
@@ -28,4 +28,3 @@ export const HelpCircleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-HelpCircleIcon.displayName = 'ForwardRef(HelpCircleIcon)'

--- a/src/icons/highlightIcon.tsx
+++ b/src/icons/highlightIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const HighlightIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function HighlightIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function HighlightIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="highlight"
@@ -28,4 +28,3 @@ export const HighlightIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-HighlightIcon.displayName = 'ForwardRef(HighlightIcon)'

--- a/src/icons/homeIcon.tsx
+++ b/src/icons/homeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const HomeIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function HomeIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function HomeIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="home"
@@ -28,4 +28,3 @@ export const HomeIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-HomeIcon.displayName = 'ForwardRef(HomeIcon)'

--- a/src/icons/iceCreamIcon.tsx
+++ b/src/icons/iceCreamIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const IceCreamIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function IceCreamIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function IceCreamIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="ice-cream"
@@ -28,4 +28,3 @@ export const IceCreamIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-IceCreamIcon.displayName = 'ForwardRef(IceCreamIcon)'

--- a/src/icons/imageIcon.tsx
+++ b/src/icons/imageIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ImageIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ImageIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ImageIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="image"
@@ -28,4 +28,3 @@ export const ImageIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ImageIcon.displayName = 'ForwardRef(ImageIcon)'

--- a/src/icons/imageRemoveIcon.tsx
+++ b/src/icons/imageRemoveIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ImageRemoveIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ImageRemoveIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ImageRemoveIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="image-remove"
@@ -28,4 +28,3 @@ export const ImageRemoveIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ImageRemoveIcon.displayName = 'ForwardRef(ImageRemoveIcon)'

--- a/src/icons/imagesIcon.tsx
+++ b/src/icons/imagesIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ImagesIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ImagesIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ImagesIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="images"
@@ -28,4 +28,3 @@ export const ImagesIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ImagesIcon.displayName = 'ForwardRef(ImagesIcon)'

--- a/src/icons/inboxIcon.tsx
+++ b/src/icons/inboxIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const InboxIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function InboxIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function InboxIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="inbox"
@@ -28,4 +28,3 @@ export const InboxIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-InboxIcon.displayName = 'ForwardRef(InboxIcon)'

--- a/src/icons/infoFilledIcon.tsx
+++ b/src/icons/infoFilledIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const InfoFilledIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function InfoFilledIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function InfoFilledIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="info-filled"
@@ -28,4 +28,3 @@ export const InfoFilledIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-InfoFilledIcon.displayName = 'ForwardRef(InfoFilledIcon)'

--- a/src/icons/infoOutlineIcon.tsx
+++ b/src/icons/infoOutlineIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const InfoOutlineIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function InfoOutlineIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function InfoOutlineIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="info-outline"
@@ -28,4 +28,3 @@ export const InfoOutlineIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-InfoOutlineIcon.displayName = 'ForwardRef(InfoOutlineIcon)'

--- a/src/icons/inlineElementIcon.tsx
+++ b/src/icons/inlineElementIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const InlineElementIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function InlineElementIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function InlineElementIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="inline-element"
@@ -28,4 +28,3 @@ export const InlineElementIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-InlineElementIcon.displayName = 'ForwardRef(InlineElementIcon)'

--- a/src/icons/inlineIcon.tsx
+++ b/src/icons/inlineIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const InlineIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function InlineIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function InlineIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="inline"
@@ -28,4 +28,3 @@ export const InlineIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-InlineIcon.displayName = 'ForwardRef(InlineIcon)'

--- a/src/icons/insertAboveIcon.tsx
+++ b/src/icons/insertAboveIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const InsertAboveIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function InsertAboveIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function InsertAboveIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="insert-above"
@@ -29,4 +29,3 @@ export const InsertAboveIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-InsertAboveIcon.displayName = 'ForwardRef(InsertAboveIcon)'

--- a/src/icons/insertBelowIcon.tsx
+++ b/src/icons/insertBelowIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const InsertBelowIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function InsertBelowIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function InsertBelowIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="insert-below"
@@ -29,4 +29,3 @@ export const InsertBelowIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-InsertBelowIcon.displayName = 'ForwardRef(InsertBelowIcon)'

--- a/src/icons/italicIcon.tsx
+++ b/src/icons/italicIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ItalicIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ItalicIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ItalicIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="italic"
@@ -26,4 +26,3 @@ export const ItalicIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ItalicIcon.displayName = 'ForwardRef(ItalicIcon)'

--- a/src/icons/joystickIcon.tsx
+++ b/src/icons/joystickIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const JoystickIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function JoystickIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function JoystickIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="joystick"
@@ -28,4 +28,3 @@ export const JoystickIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-JoystickIcon.displayName = 'ForwardRef(JoystickIcon)'

--- a/src/icons/jsonIcon.tsx
+++ b/src/icons/jsonIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const JsonIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function JsonIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function JsonIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="json"
@@ -28,4 +28,3 @@ export const JsonIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-JsonIcon.displayName = 'ForwardRef(JsonIcon)'

--- a/src/icons/launchIcon.tsx
+++ b/src/icons/launchIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LaunchIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LaunchIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LaunchIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="launch"
@@ -29,4 +29,3 @@ export const LaunchIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LaunchIcon.displayName = 'ForwardRef(LaunchIcon)'

--- a/src/icons/leaveIcon.tsx
+++ b/src/icons/leaveIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LeaveIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LeaveIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LeaveIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="leave"
@@ -34,4 +34,3 @@ export const LeaveIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LeaveIcon.displayName = 'ForwardRef(LeaveIcon)'

--- a/src/icons/lemonIcon.tsx
+++ b/src/icons/lemonIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LemonIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LemonIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LemonIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="lemon"
@@ -28,4 +28,3 @@ export const LemonIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LemonIcon.displayName = 'ForwardRef(LemonIcon)'

--- a/src/icons/linkIcon.tsx
+++ b/src/icons/linkIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LinkIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LinkIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LinkIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="link"
@@ -28,4 +28,3 @@ export const LinkIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LinkIcon.displayName = 'ForwardRef(LinkIcon)'

--- a/src/icons/linkRemovedIcon.tsx
+++ b/src/icons/linkRemovedIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LinkRemovedIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LinkRemovedIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LinkRemovedIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="link-removed"
@@ -28,4 +28,3 @@ export const LinkRemovedIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LinkRemovedIcon.displayName = 'ForwardRef(LinkRemovedIcon)'

--- a/src/icons/linkedinIcon.tsx
+++ b/src/icons/linkedinIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LinkedinIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LinkedinIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LinkedinIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="linkedin"
@@ -26,4 +26,3 @@ export const LinkedinIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LinkedinIcon.displayName = 'ForwardRef(LinkedinIcon)'

--- a/src/icons/listIcon.tsx
+++ b/src/icons/listIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ListIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ListIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ListIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="list"
@@ -28,4 +28,3 @@ export const ListIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ListIcon.displayName = 'ForwardRef(ListIcon)'

--- a/src/icons/lockIcon.tsx
+++ b/src/icons/lockIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LockIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LockIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LockIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="lock"
@@ -28,4 +28,3 @@ export const LockIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LockIcon.displayName = 'ForwardRef(LockIcon)'

--- a/src/icons/logoJsIcon.tsx
+++ b/src/icons/logoJsIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LogoJsIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LogoJsIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LogoJsIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="logo-js"
@@ -28,4 +28,3 @@ export const LogoJsIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LogoJsIcon.displayName = 'ForwardRef(LogoJsIcon)'

--- a/src/icons/logoTsIcon.tsx
+++ b/src/icons/logoTsIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const LogoTsIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function LogoTsIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function LogoTsIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="logo-ts"
@@ -28,4 +28,3 @@ export const LogoTsIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-LogoTsIcon.displayName = 'ForwardRef(LogoTsIcon)'

--- a/src/icons/markerIcon.tsx
+++ b/src/icons/markerIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const MarkerIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function MarkerIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function MarkerIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="marker"
@@ -34,4 +34,3 @@ export const MarkerIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-MarkerIcon.displayName = 'ForwardRef(MarkerIcon)'

--- a/src/icons/markerRemovedIcon.tsx
+++ b/src/icons/markerRemovedIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const MarkerRemovedIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function MarkerRemovedIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function MarkerRemovedIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="marker-removed"
@@ -28,4 +28,3 @@ export const MarkerRemovedIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-MarkerRemovedIcon.displayName = 'ForwardRef(MarkerRemovedIcon)'

--- a/src/icons/masterDetailIcon.tsx
+++ b/src/icons/masterDetailIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const MasterDetailIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function MasterDetailIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function MasterDetailIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="master-detail"
@@ -28,4 +28,3 @@ export const MasterDetailIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-MasterDetailIcon.displayName = 'ForwardRef(MasterDetailIcon)'

--- a/src/icons/menuIcon.tsx
+++ b/src/icons/menuIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const MenuIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function MenuIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function MenuIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="menu"
@@ -28,4 +28,3 @@ export const MenuIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-MenuIcon.displayName = 'ForwardRef(MenuIcon)'

--- a/src/icons/microphoneIcon.tsx
+++ b/src/icons/microphoneIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const MicrophoneIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function MicrophoneIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function MicrophoneIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="microphone"
@@ -27,4 +27,3 @@ export const MicrophoneIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-MicrophoneIcon.displayName = 'ForwardRef(MicrophoneIcon)'

--- a/src/icons/microphoneSlashIcon.tsx
+++ b/src/icons/microphoneSlashIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const MicrophoneSlashIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function MicrophoneSlashIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function MicrophoneSlashIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="microphone-slash"
@@ -39,4 +39,3 @@ export const MicrophoneSlashIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-MicrophoneSlashIcon.displayName = 'ForwardRef(MicrophoneSlashIcon)'

--- a/src/icons/mobileDeviceIcon.tsx
+++ b/src/icons/mobileDeviceIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const MobileDeviceIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function MobileDeviceIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function MobileDeviceIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="mobile-device"
@@ -34,4 +34,3 @@ export const MobileDeviceIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-MobileDeviceIcon.displayName = 'ForwardRef(MobileDeviceIcon)'

--- a/src/icons/moonIcon.tsx
+++ b/src/icons/moonIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const MoonIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function MoonIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function MoonIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="moon"
@@ -28,4 +28,3 @@ export const MoonIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-MoonIcon.displayName = 'ForwardRef(MoonIcon)'

--- a/src/icons/numberIcon.tsx
+++ b/src/icons/numberIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const NumberIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function NumberIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function NumberIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="number"
@@ -40,4 +40,3 @@ export const NumberIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-NumberIcon.displayName = 'ForwardRef(NumberIcon)'

--- a/src/icons/okHandIcon.tsx
+++ b/src/icons/okHandIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const OkHandIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function OkHandIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function OkHandIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="ok-hand"
@@ -28,4 +28,3 @@ export const OkHandIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-OkHandIcon.displayName = 'ForwardRef(OkHandIcon)'

--- a/src/icons/olistIcon.tsx
+++ b/src/icons/olistIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const OlistIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function OlistIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function OlistIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="olist"
@@ -28,4 +28,3 @@ export const OlistIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-OlistIcon.displayName = 'ForwardRef(OlistIcon)'

--- a/src/icons/overageIcon.tsx
+++ b/src/icons/overageIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const OverageIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function OverageIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function OverageIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="overage"
@@ -29,4 +29,3 @@ export const OverageIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-OverageIcon.displayName = 'ForwardRef(OverageIcon)'

--- a/src/icons/packageIcon.tsx
+++ b/src/icons/packageIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PackageIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PackageIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PackageIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="package"
@@ -28,4 +28,3 @@ export const PackageIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PackageIcon.displayName = 'ForwardRef(PackageIcon)'

--- a/src/icons/panelLeftIcon.tsx
+++ b/src/icons/panelLeftIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PanelLeftIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PanelLeftIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PanelLeftIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="panel-left"
@@ -28,4 +28,3 @@ export const PanelLeftIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PanelLeftIcon.displayName = 'ForwardRef(PanelLeftIcon)'

--- a/src/icons/panelRightIcon.tsx
+++ b/src/icons/panelRightIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PanelRightIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PanelRightIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PanelRightIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="panel-right"
@@ -28,4 +28,3 @@ export const PanelRightIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PanelRightIcon.displayName = 'ForwardRef(PanelRightIcon)'

--- a/src/icons/pauseIcon.tsx
+++ b/src/icons/pauseIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PauseIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PauseIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PauseIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="pause"
@@ -26,4 +26,3 @@ export const PauseIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PauseIcon.displayName = 'ForwardRef(PauseIcon)'

--- a/src/icons/pinFilledIcon.tsx
+++ b/src/icons/pinFilledIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PinFilledIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PinFilledIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PinFilledIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="pin-filled"
@@ -35,4 +35,3 @@ export const PinFilledIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PinFilledIcon.displayName = 'ForwardRef(PinFilledIcon)'

--- a/src/icons/pinIcon.tsx
+++ b/src/icons/pinIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PinIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PinIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PinIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="pin"
@@ -34,4 +34,3 @@ export const PinIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PinIcon.displayName = 'ForwardRef(PinIcon)'

--- a/src/icons/pinRemovedIcon.tsx
+++ b/src/icons/pinRemovedIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PinRemovedIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PinRemovedIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PinRemovedIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="pin-removed"
@@ -28,4 +28,3 @@ export const PinRemovedIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PinRemovedIcon.displayName = 'ForwardRef(PinRemovedIcon)'

--- a/src/icons/playIcon.tsx
+++ b/src/icons/playIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PlayIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PlayIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PlayIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="play"
@@ -29,4 +29,3 @@ export const PlayIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PlayIcon.displayName = 'ForwardRef(PlayIcon)'

--- a/src/icons/plugIcon.tsx
+++ b/src/icons/plugIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PlugIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PlugIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PlugIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="plug"
@@ -28,4 +28,3 @@ export const PlugIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PlugIcon.displayName = 'ForwardRef(PlugIcon)'

--- a/src/icons/presentationIcon.tsx
+++ b/src/icons/presentationIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PresentationIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PresentationIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PresentationIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="presentation"
@@ -28,4 +28,3 @@ export const PresentationIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PresentationIcon.displayName = 'ForwardRef(PresentationIcon)'

--- a/src/icons/progress50Icon.tsx
+++ b/src/icons/progress50Icon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const Progress50Icon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function Progress50Icon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function Progress50Icon(props, ref) {
   return (
     <svg
       data-sanity-icon="progress-50"
@@ -35,4 +35,3 @@ export const Progress50Icon: ForwardRefExoticComponent<
     </svg>
   )
 })
-Progress50Icon.displayName = 'ForwardRef(Progress50Icon)'

--- a/src/icons/progress75Icon.tsx
+++ b/src/icons/progress75Icon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const Progress75Icon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function Progress75Icon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function Progress75Icon(props, ref) {
   return (
     <svg
       data-sanity-icon="progress-75"
@@ -35,4 +35,3 @@ export const Progress75Icon: ForwardRefExoticComponent<
     </svg>
   )
 })
-Progress75Icon.displayName = 'ForwardRef(Progress75Icon)'

--- a/src/icons/projectsIcon.tsx
+++ b/src/icons/projectsIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ProjectsIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ProjectsIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ProjectsIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="projects"
@@ -28,4 +28,3 @@ export const ProjectsIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ProjectsIcon.displayName = 'ForwardRef(ProjectsIcon)'

--- a/src/icons/publishIcon.tsx
+++ b/src/icons/publishIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const PublishIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function PublishIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function PublishIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="publish"
@@ -34,4 +34,3 @@ export const PublishIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-PublishIcon.displayName = 'ForwardRef(PublishIcon)'

--- a/src/icons/readOnlyIcon.tsx
+++ b/src/icons/readOnlyIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ReadOnlyIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ReadOnlyIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ReadOnlyIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="read-only"
@@ -28,4 +28,3 @@ export const ReadOnlyIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ReadOnlyIcon.displayName = 'ForwardRef(ReadOnlyIcon)'

--- a/src/icons/redoIcon.tsx
+++ b/src/icons/redoIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RedoIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RedoIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RedoIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="redo"
@@ -34,4 +34,3 @@ export const RedoIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RedoIcon.displayName = 'ForwardRef(RedoIcon)'

--- a/src/icons/refreshIcon.tsx
+++ b/src/icons/refreshIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RefreshIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RefreshIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RefreshIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="refresh"
@@ -34,4 +34,3 @@ export const RefreshIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RefreshIcon.displayName = 'ForwardRef(RefreshIcon)'

--- a/src/icons/removeCircleIcon.tsx
+++ b/src/icons/removeCircleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RemoveCircleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RemoveCircleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RemoveCircleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="remove-circle"
@@ -28,4 +28,3 @@ export const RemoveCircleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RemoveCircleIcon.displayName = 'ForwardRef(RemoveCircleIcon)'

--- a/src/icons/removeIcon.tsx
+++ b/src/icons/removeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RemoveIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RemoveIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RemoveIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="remove"
@@ -23,4 +23,3 @@ export const RemoveIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RemoveIcon.displayName = 'ForwardRef(RemoveIcon)'

--- a/src/icons/resetIcon.tsx
+++ b/src/icons/resetIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ResetIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ResetIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ResetIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="reset"
@@ -34,4 +34,3 @@ export const ResetIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ResetIcon.displayName = 'ForwardRef(ResetIcon)'

--- a/src/icons/restoreIcon.tsx
+++ b/src/icons/restoreIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RestoreIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RestoreIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RestoreIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="restore"
@@ -34,4 +34,3 @@ export const RestoreIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RestoreIcon.displayName = 'ForwardRef(RestoreIcon)'

--- a/src/icons/retrieveIcon.tsx
+++ b/src/icons/retrieveIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RetrieveIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RetrieveIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RetrieveIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="retrieve"
@@ -34,4 +34,3 @@ export const RetrieveIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RetrieveIcon.displayName = 'ForwardRef(RetrieveIcon)'

--- a/src/icons/retryIcon.tsx
+++ b/src/icons/retryIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RetryIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RetryIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RetryIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="retry"
@@ -34,4 +34,3 @@ export const RetryIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RetryIcon.displayName = 'ForwardRef(RetryIcon)'

--- a/src/icons/revertIcon.tsx
+++ b/src/icons/revertIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RevertIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RevertIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RevertIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="revert"
@@ -34,4 +34,3 @@ export const RevertIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RevertIcon.displayName = 'ForwardRef(RevertIcon)'

--- a/src/icons/robotIcon.tsx
+++ b/src/icons/robotIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RobotIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RobotIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RobotIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="robot"
@@ -28,4 +28,3 @@ export const RobotIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RobotIcon.displayName = 'ForwardRef(RobotIcon)'

--- a/src/icons/rocketIcon.tsx
+++ b/src/icons/rocketIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const RocketIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function RocketIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function RocketIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="rocket"
@@ -28,4 +28,3 @@ export const RocketIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-RocketIcon.displayName = 'ForwardRef(RocketIcon)'

--- a/src/icons/schemaIcon.tsx
+++ b/src/icons/schemaIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SchemaIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SchemaIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SchemaIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="schema"
@@ -28,4 +28,3 @@ export const SchemaIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SchemaIcon.displayName = 'ForwardRef(SchemaIcon)'

--- a/src/icons/searchIcon.tsx
+++ b/src/icons/searchIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SearchIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SearchIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SearchIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="search"
@@ -28,4 +28,3 @@ export const SearchIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SearchIcon.displayName = 'ForwardRef(SearchIcon)'

--- a/src/icons/selectIcon.tsx
+++ b/src/icons/selectIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SelectIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SelectIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SelectIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="select"
@@ -28,4 +28,3 @@ export const SelectIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SelectIcon.displayName = 'ForwardRef(SelectIcon)'

--- a/src/icons/shareIcon.tsx
+++ b/src/icons/shareIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ShareIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ShareIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ShareIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="share"
@@ -29,4 +29,3 @@ export const ShareIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ShareIcon.displayName = 'ForwardRef(ShareIcon)'

--- a/src/icons/sortIcon.tsx
+++ b/src/icons/sortIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SortIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SortIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SortIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="sort"
@@ -28,4 +28,3 @@ export const SortIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SortIcon.displayName = 'ForwardRef(SortIcon)'

--- a/src/icons/sparkleIcon.tsx
+++ b/src/icons/sparkleIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SparkleIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SparkleIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SparkleIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="sparkle"
@@ -28,4 +28,3 @@ export const SparkleIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SparkleIcon.displayName = 'ForwardRef(SparkleIcon)'

--- a/src/icons/sparklesIcon.tsx
+++ b/src/icons/sparklesIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SparklesIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SparklesIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SparklesIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="sparkles"
@@ -29,4 +29,3 @@ export const SparklesIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SparklesIcon.displayName = 'ForwardRef(SparklesIcon)'

--- a/src/icons/spinnerIcon.tsx
+++ b/src/icons/spinnerIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SpinnerIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SpinnerIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SpinnerIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="spinner"
@@ -28,4 +28,3 @@ export const SpinnerIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SpinnerIcon.displayName = 'ForwardRef(SpinnerIcon)'

--- a/src/icons/splitHorizontalIcon.tsx
+++ b/src/icons/splitHorizontalIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SplitHorizontalIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SplitHorizontalIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SplitHorizontalIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="split-horizontal"
@@ -28,4 +28,3 @@ export const SplitHorizontalIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SplitHorizontalIcon.displayName = 'ForwardRef(SplitHorizontalIcon)'

--- a/src/icons/splitVerticalIcon.tsx
+++ b/src/icons/splitVerticalIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SplitVerticalIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SplitVerticalIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SplitVerticalIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="split-vertical"
@@ -28,4 +28,3 @@ export const SplitVerticalIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SplitVerticalIcon.displayName = 'ForwardRef(SplitVerticalIcon)'

--- a/src/icons/squareIcon.tsx
+++ b/src/icons/squareIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SquareIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SquareIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SquareIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="square"
@@ -31,4 +31,3 @@ export const SquareIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SquareIcon.displayName = 'ForwardRef(SquareIcon)'

--- a/src/icons/stackCompactIcon.tsx
+++ b/src/icons/stackCompactIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const StackCompactIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function StackCompactIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function StackCompactIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="stack-compact"
@@ -28,4 +28,3 @@ export const StackCompactIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-StackCompactIcon.displayName = 'ForwardRef(StackCompactIcon)'

--- a/src/icons/stackIcon.tsx
+++ b/src/icons/stackIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const StackIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function StackIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function StackIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="stack"
@@ -28,4 +28,3 @@ export const StackIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-StackIcon.displayName = 'ForwardRef(StackIcon)'

--- a/src/icons/starFilledIcon.tsx
+++ b/src/icons/starFilledIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const StarFilledIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function StarFilledIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function StarFilledIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="star-filled"
@@ -28,4 +28,3 @@ export const StarFilledIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-StarFilledIcon.displayName = 'ForwardRef(StarFilledIcon)'

--- a/src/icons/starIcon.tsx
+++ b/src/icons/starIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const StarIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function StarIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function StarIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="star"
@@ -28,4 +28,3 @@ export const StarIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-StarIcon.displayName = 'ForwardRef(StarIcon)'

--- a/src/icons/stopIcon.tsx
+++ b/src/icons/stopIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const StopIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function StopIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function StopIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="stop"
@@ -32,4 +32,3 @@ export const StopIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-StopIcon.displayName = 'ForwardRef(StopIcon)'

--- a/src/icons/strikethroughIcon.tsx
+++ b/src/icons/strikethroughIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const StrikethroughIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function StrikethroughIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function StrikethroughIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="strikethrough"
@@ -31,4 +31,3 @@ export const StrikethroughIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-StrikethroughIcon.displayName = 'ForwardRef(StrikethroughIcon)'

--- a/src/icons/stringIcon.tsx
+++ b/src/icons/stringIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const StringIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function StringIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function StringIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="string"
@@ -36,4 +36,3 @@ export const StringIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-StringIcon.displayName = 'ForwardRef(StringIcon)'

--- a/src/icons/sunIcon.tsx
+++ b/src/icons/sunIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SunIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SunIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SunIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="sun"
@@ -28,4 +28,3 @@ export const SunIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SunIcon.displayName = 'ForwardRef(SunIcon)'

--- a/src/icons/syncIcon.tsx
+++ b/src/icons/syncIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const SyncIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function SyncIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function SyncIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="sync"
@@ -34,4 +34,3 @@ export const SyncIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-SyncIcon.displayName = 'ForwardRef(SyncIcon)'

--- a/src/icons/tabletDeviceIcon.tsx
+++ b/src/icons/tabletDeviceIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TabletDeviceIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TabletDeviceIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TabletDeviceIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="tablet-device"
@@ -34,4 +34,3 @@ export const TabletDeviceIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TabletDeviceIcon.displayName = 'ForwardRef(TabletDeviceIcon)'

--- a/src/icons/tagIcon.tsx
+++ b/src/icons/tagIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TagIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TagIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TagIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="tag"
@@ -34,4 +34,3 @@ export const TagIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TagIcon.displayName = 'ForwardRef(TagIcon)'

--- a/src/icons/tagsIcon.tsx
+++ b/src/icons/tagsIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TagsIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TagsIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TagsIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="tags"
@@ -28,4 +28,3 @@ export const TagsIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TagsIcon.displayName = 'ForwardRef(TagsIcon)'

--- a/src/icons/targetIcon.tsx
+++ b/src/icons/targetIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TargetIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TargetIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TargetIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="target"
@@ -28,4 +28,3 @@ export const TargetIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TargetIcon.displayName = 'ForwardRef(TargetIcon)'

--- a/src/icons/taskIcon.tsx
+++ b/src/icons/taskIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TaskIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TaskIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TaskIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="task"
@@ -28,4 +28,3 @@ export const TaskIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TaskIcon.displayName = 'ForwardRef(TaskIcon)'

--- a/src/icons/terminalIcon.tsx
+++ b/src/icons/terminalIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TerminalIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TerminalIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TerminalIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="terminal"
@@ -28,4 +28,3 @@ export const TerminalIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TerminalIcon.displayName = 'ForwardRef(TerminalIcon)'

--- a/src/icons/textIcon.tsx
+++ b/src/icons/textIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TextIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TextIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TextIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="text"
@@ -28,4 +28,3 @@ export const TextIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TextIcon.displayName = 'ForwardRef(TextIcon)'

--- a/src/icons/thLargeIcon.tsx
+++ b/src/icons/thLargeIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ThLargeIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ThLargeIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ThLargeIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="th-large"
@@ -28,4 +28,3 @@ export const ThLargeIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ThLargeIcon.displayName = 'ForwardRef(ThLargeIcon)'

--- a/src/icons/thListIcon.tsx
+++ b/src/icons/thListIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ThListIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ThListIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ThListIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="th-list"
@@ -28,4 +28,3 @@ export const ThListIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ThListIcon.displayName = 'ForwardRef(ThListIcon)'

--- a/src/icons/thumbsDownIcon.tsx
+++ b/src/icons/thumbsDownIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ThumbsDownIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ThumbsDownIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ThumbsDownIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="thumbs-down"
@@ -28,4 +28,3 @@ export const ThumbsDownIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ThumbsDownIcon.displayName = 'ForwardRef(ThumbsDownIcon)'

--- a/src/icons/thumbsUpIcon.tsx
+++ b/src/icons/thumbsUpIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ThumbsUpIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ThumbsUpIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ThumbsUpIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="thumbs-up"
@@ -28,4 +28,3 @@ export const ThumbsUpIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ThumbsUpIcon.displayName = 'ForwardRef(ThumbsUpIcon)'

--- a/src/icons/tiersIcon.tsx
+++ b/src/icons/tiersIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TiersIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TiersIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TiersIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="tiers"
@@ -28,4 +28,3 @@ export const TiersIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TiersIcon.displayName = 'ForwardRef(TiersIcon)'

--- a/src/icons/timelineIcon.tsx
+++ b/src/icons/timelineIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TimelineIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TimelineIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TimelineIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="timeline"
@@ -28,4 +28,3 @@ export const TimelineIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TimelineIcon.displayName = 'ForwardRef(TimelineIcon)'

--- a/src/icons/toggleArrowRightIcon.tsx
+++ b/src/icons/toggleArrowRightIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const ToggleArrowRightIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function ToggleArrowRightIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function ToggleArrowRightIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="toggle-arrow-right"
@@ -28,4 +28,3 @@ export const ToggleArrowRightIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-ToggleArrowRightIcon.displayName = 'ForwardRef(ToggleArrowRightIcon)'

--- a/src/icons/tokenIcon.tsx
+++ b/src/icons/tokenIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TokenIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TokenIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TokenIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="token"
@@ -28,4 +28,3 @@ export const TokenIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TokenIcon.displayName = 'ForwardRef(TokenIcon)'

--- a/src/icons/transferIcon.tsx
+++ b/src/icons/transferIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TransferIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TransferIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TransferIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="transfer"
@@ -34,4 +34,3 @@ export const TransferIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TransferIcon.displayName = 'ForwardRef(TransferIcon)'

--- a/src/icons/translateIcon.tsx
+++ b/src/icons/translateIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TranslateIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TranslateIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TranslateIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="translate"
@@ -28,4 +28,3 @@ export const TranslateIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TranslateIcon.displayName = 'ForwardRef(TranslateIcon)'

--- a/src/icons/trashIcon.tsx
+++ b/src/icons/trashIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TrashIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TrashIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TrashIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="trash"
@@ -28,4 +28,3 @@ export const TrashIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TrashIcon.displayName = 'ForwardRef(TrashIcon)'

--- a/src/icons/trendUpwardIcon.tsx
+++ b/src/icons/trendUpwardIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TrendUpwardIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TrendUpwardIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TrendUpwardIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="trend-upward"
@@ -29,4 +29,3 @@ export const TrendUpwardIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TrendUpwardIcon.displayName = 'ForwardRef(TrendUpwardIcon)'

--- a/src/icons/triangleOutlineIcon.tsx
+++ b/src/icons/triangleOutlineIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TriangleOutlineIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TriangleOutlineIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TriangleOutlineIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="triangle-outline"
@@ -28,4 +28,3 @@ export const TriangleOutlineIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TriangleOutlineIcon.displayName = 'ForwardRef(TriangleOutlineIcon)'

--- a/src/icons/trolleyIcon.tsx
+++ b/src/icons/trolleyIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TrolleyIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TrolleyIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TrolleyIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="trolley"
@@ -28,4 +28,3 @@ export const TrolleyIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TrolleyIcon.displayName = 'ForwardRef(TrolleyIcon)'

--- a/src/icons/truncateIcon.tsx
+++ b/src/icons/truncateIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TruncateIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TruncateIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TruncateIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="truncate"
@@ -28,4 +28,3 @@ export const TruncateIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TruncateIcon.displayName = 'ForwardRef(TruncateIcon)'

--- a/src/icons/twitterIcon.tsx
+++ b/src/icons/twitterIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const TwitterIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function TwitterIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function TwitterIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="twitter"
@@ -26,4 +26,3 @@ export const TwitterIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-TwitterIcon.displayName = 'ForwardRef(TwitterIcon)'

--- a/src/icons/ulistIcon.tsx
+++ b/src/icons/ulistIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UlistIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UlistIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UlistIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="ulist"
@@ -46,4 +46,3 @@ export const UlistIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UlistIcon.displayName = 'ForwardRef(UlistIcon)'

--- a/src/icons/unarchiveIcon.tsx
+++ b/src/icons/unarchiveIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UnarchiveIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UnarchiveIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UnarchiveIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="unarchive"
@@ -34,4 +34,3 @@ export const UnarchiveIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UnarchiveIcon.displayName = 'ForwardRef(UnarchiveIcon)'

--- a/src/icons/underlineIcon.tsx
+++ b/src/icons/underlineIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UnderlineIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UnderlineIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UnderlineIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="underline"
@@ -27,4 +27,3 @@ export const UnderlineIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UnderlineIcon.displayName = 'ForwardRef(UnderlineIcon)'

--- a/src/icons/undoIcon.tsx
+++ b/src/icons/undoIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UndoIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UndoIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UndoIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="undo"
@@ -34,4 +34,3 @@ export const UndoIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UndoIcon.displayName = 'ForwardRef(UndoIcon)'

--- a/src/icons/unknownIcon.tsx
+++ b/src/icons/unknownIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UnknownIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UnknownIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UnknownIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="unknown"
@@ -28,4 +28,3 @@ export const UnknownIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UnknownIcon.displayName = 'ForwardRef(UnknownIcon)'

--- a/src/icons/unlinkIcon.tsx
+++ b/src/icons/unlinkIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UnlinkIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UnlinkIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UnlinkIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="unlink"
@@ -28,4 +28,3 @@ export const UnlinkIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UnlinkIcon.displayName = 'ForwardRef(UnlinkIcon)'

--- a/src/icons/unlockIcon.tsx
+++ b/src/icons/unlockIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UnlockIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UnlockIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UnlockIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="unlock"
@@ -28,4 +28,3 @@ export const UnlockIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UnlockIcon.displayName = 'ForwardRef(UnlockIcon)'

--- a/src/icons/unpublishIcon.tsx
+++ b/src/icons/unpublishIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UnpublishIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UnpublishIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UnpublishIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="unpublish"
@@ -34,4 +34,3 @@ export const UnpublishIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UnpublishIcon.displayName = 'ForwardRef(UnpublishIcon)'

--- a/src/icons/uploadIcon.tsx
+++ b/src/icons/uploadIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UploadIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UploadIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UploadIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="upload"
@@ -34,4 +34,3 @@ export const UploadIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UploadIcon.displayName = 'ForwardRef(UploadIcon)'

--- a/src/icons/userIcon.tsx
+++ b/src/icons/userIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UserIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UserIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UserIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="user"
@@ -28,4 +28,3 @@ export const UserIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UserIcon.displayName = 'ForwardRef(UserIcon)'

--- a/src/icons/usersIcon.tsx
+++ b/src/icons/usersIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const UsersIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function UsersIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function UsersIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="users"
@@ -28,4 +28,3 @@ export const UsersIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-UsersIcon.displayName = 'ForwardRef(UsersIcon)'

--- a/src/icons/versionsIcon.tsx
+++ b/src/icons/versionsIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const VersionsIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function VersionsIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function VersionsIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="versions"
@@ -34,4 +34,3 @@ export const VersionsIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-VersionsIcon.displayName = 'ForwardRef(VersionsIcon)'

--- a/src/icons/videoIcon.tsx
+++ b/src/icons/videoIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const VideoIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function VideoIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function VideoIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="video"
@@ -35,4 +35,3 @@ export const VideoIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-VideoIcon.displayName = 'ForwardRef(VideoIcon)'

--- a/src/icons/warningFilledIcon.tsx
+++ b/src/icons/warningFilledIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const WarningFilledIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function WarningFilledIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function WarningFilledIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="warning-filled"
@@ -28,4 +28,3 @@ export const WarningFilledIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-WarningFilledIcon.displayName = 'ForwardRef(WarningFilledIcon)'

--- a/src/icons/warningOutlineIcon.tsx
+++ b/src/icons/warningOutlineIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const WarningOutlineIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function WarningOutlineIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function WarningOutlineIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="warning-outline"
@@ -28,4 +28,3 @@ export const WarningOutlineIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-WarningOutlineIcon.displayName = 'ForwardRef(WarningOutlineIcon)'

--- a/src/icons/wrenchIcon.tsx
+++ b/src/icons/wrenchIcon.tsx
@@ -7,7 +7,7 @@ import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVG
  */
 export const WrenchIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
-> = forwardRef(function WrenchIcon(props, ref) {
+> = /* @__PURE__ */ forwardRef(function WrenchIcon(props, ref) {
   return (
     <svg
       data-sanity-icon="wrench"
@@ -26,4 +26,3 @@ export const WrenchIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
-WrenchIcon.displayName = 'ForwardRef(WrenchIcon)'


### PR DESCRIPTION
Unfortunately assigning `.displayName` breaks treeshaking, it's seen as a side-effect.
Additionally the `forwardRef` call also marks the export as having a side-effect. This PR adds `@__PURE__` annotations so that tooling understands it's ok to remove unused icons.
Without these annotations userland would have to add `forwardRef` to their `treeshake.manualPureFunctions` array (or equivalent).

The icons package is pretty heavy: https://bundlephobia.com/package/@sanity/icons@3.7.3 so the convenience of `.displayName` for debugging purposes is outweighed by the inability to tree-shake.