### PR TITLE
fix: connect diamond icon stroke corners

### DIFF
--- a/export/diamond.svg
+++ b/export/diamond.svg
@@ -1,3 +1,3 @@
 <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M21 10.5L12.5 21M21 10.5L18 5.5H11M21 10.5H16M12.5 21L4 10.5M12.5 21L9 10.5M12.5 21L16 10.5M4 10.5L7 5.5H11M4 10.5H9M9 10.5H12.5H16M9 10.5L11 5.5M16 10.5L14.5 5.5H11" stroke="#0D0E12" stroke-width="1.2" stroke-linejoin="round"/>
+<path d="M21 10.5L12.5 21M21 10.5L18 5.5H11M21 10.5H16M12.5 21L4 10.5M12.5 21L9 10.5M12.5 21L16 10.5M4 10.5L7 5.5H11M4 10.5H9M9 10.5H12.5H16M9 10.5L11 5.5M16 10.5L14.5 5.5H11" stroke="#0D0E12" stroke-width="1.2" stroke-linejoin="round" stroke-linecap="round"/>
 </svg>

--- a/src/icons/diamondIcon.tsx
+++ b/src/icons/diamondIcon.tsx
@@ -24,6 +24,7 @@ export const DiamondIcon: ForwardRefExoticComponent<
         stroke="currentColor"
         strokeWidth={1.2}
         strokeLinejoin="round"
+        strokeLinecap="round"
       />
     </svg>
   )


### PR DESCRIPTION
Fixes #165

## Problem
The diamond icon has disconnected strokes at its corners, visible especially at larger sizes. The path uses multiple disconnected subpaths (each starting with `M`) that converge at the same corner vertices. Without `stroke-linecap` set, the default `butt` cap creates flat endpoints that don't visually close where lines meet.

## Fix
Add `stroke-linecap="round"` to `export/diamond.svg`, matching the existing `stroke-linejoin="round"`. The TSX component is regenerated via `pnpm generate`.

## Changes
- `export/diamond.svg` — add `stroke-linecap="round"` to `<path>`
- `src/icons/diamondIcon.tsx` — regenerated (adds `strokeLinecap="round"`)