### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`@sanity/icons` is a single-package React icon library (pnpm, TypeScript). There is one runnable service: a Vite "workshop" showcase app that renders all icons with a name filter.
+
+- Package manager is pnpm (`pnpm-lock.yaml`). Node 24 is auto-provisioned by pnpm via `devEngines` during `pnpm install`, so the system Node version does not matter.
+- Standard commands live in `package.json` scripts; use them directly:
+  - Dev showcase app: `pnpm dev` (Vite on http://localhost:5173/, entry `src/__workshop__/main.tsx`).
+  - Lint: `pnpm lint` (oxlint). Format: `pnpm format` (oxfmt).
+  - Test: `pnpm test` (vitest, jsdom).
+  - Build the library: `pnpm build` (runs `clean` → `generate` → `pkg:build` → `pkg:check`).
+  - Dead-code/deps check: `pnpm knip`.
+- Non-obvious: `pnpm build` runs `generate`, which deletes and regenerates `src/icons/*` and `src/icons/index.ts` from the SVG sources in `export/`. These generated files are committed; do not hand-edit them—edit the SVGs in `export/` or `scripts/generate.ts` instead.
+- The pre-commit hook (lefthook) runs oxfmt + oxlint on staged files.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for `@sanity/icons`, and documents non-obvious setup notes for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the runnable showcase app, standard commands, and the `generate`-on-build gotcha.
- Update script (VM startup): `pnpm install` (Node 24 is auto-provisioned by pnpm via `devEngines`).

## Verification

All standard workflows were run successfully:

- `pnpm install`
- `pnpm lint` (oxlint)
- `pnpm test` (vitest — 1 file, 1 test passed)
- `pnpm build` (clean → generate → pkg build → pkg check)
- `pnpm knip`
- `pnpm dev` — Vite showcase served at http://localhost:5173/

### Hello-world demo

Loaded the icon showcase and filtered the list by typing "rocket" in the filter box, confirming icons render and filtering works.

[sanity_icons_showcase_filter_demo.mp4](https://cursor.com/agents/bc-bdc3d032-bd81-445e-a0a6-cceca628396b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsanity_icons_showcase_filter_demo.mp4)

[All icons rendered](https://cursor.com/agents/bc-bdc3d032-bd81-445e-a0a6-cceca628396b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ficons_showcase_all.webp)
[Filtered to rocket icon](https://cursor.com/agents/bc-bdc3d032-bd81-445e-a0a6-cceca628396b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ficons_showcase_rocket_filter.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdc3d032-bd81-445e-a0a6-cceca628396b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdc3d032-bd81-445e-a0a6-cceca628396b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

