### PR TITLE
Use icon_ prefix for icon document ids

### DIFF
--- a/functions/enrich-icon/index.ts
+++ b/functions/enrich-icon/index.ts
@@ -16,7 +16,7 @@ export const handler = documentEventHandler<IconEvent>(async ({context, event}) 
     useCdn: false,
   })
 
-  const label = _id.replace(/^icon\./, '')
+  const label = _id.replace(/^icon_/, '')
 
   // 1. Use Sanity's native vision model (Agent Actions) to look at the
   //    rasterized icon and write a search-friendly description.

--- a/scripts/seed-icons-dataset.ts
+++ b/scripts/seed-icons-dataset.ts
@@ -69,7 +69,9 @@ async function main() {
 
   for (const filePath of filePaths) {
     const key = iconKeyFromPath(filePath)
-    const _id = `icon.${key}`
+    // Prefix with `icon_` (not `icon.`): `.` is a document-id namespace separator
+    // in Sanity and segments like "versions" are reserved.
+    const _id = `icon_${key}`
     // The literal filename as it exists in `export/` (e.g. "add-user.svg").
     const filename = path.relative(IMPORT_PATH, filePath).split(path.sep).join('/')
     // The ESM named export, matching scripts/generate.ts (e.g. "AddUserIcon").

--- a/src/__workshop__/use-icon-search.ts
+++ b/src/__workshop__/use-icon-search.ts
@@ -6,7 +6,7 @@ import {searchClient} from './sanity-client'
 // Hybrid ranking: exact filename, then prefix, then keyword matches across
 // filename/namedExport/tags/description, and finally semantic similarity.
 // Keyword boosts are weighted high so exact/partial matches always rank above
-// fuzzy ones. The icon key is recovered from `_id` ("icon.<key>").
+// fuzzy ones. The icon key is recovered from `_id` ("icon_<key>").
 const SEARCH_QUERY = `*[_type == "icon"] | score(
   boost(filename == $qExact, 12),
   boost(filename match $qPrefix, 8),
@@ -59,7 +59,7 @@ export function useIconSearch(query: string): IconSearchState {
 
         // Recover the icon key from `_id` and keep only icons in the shipped set.
         const names = rows
-          .map((row) => row.id.replace(/^icon\./, ''))
+          .map((row) => row.id.replace(/^icon_/, ''))
           .filter((name) => name in icons)
 
         setRemote({query: trimmed, names, semantic: true})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The seed failed on `versions.svg`:

```
Invalid document version ID "icon.versions": invalid use of "versions" in "versions"
```

`.` is a document-id namespace separator in Sanity, and segments like `versions` (and `drafts`) are reserved, so `icon.versions` is rejected. Switching the id scheme from `icon.<key>` to `icon_<key>` avoids the `.` entirely, so all icon names (including `versions`) are valid.

## Changes

- `scripts/seed-icons-dataset.ts`: `_id` is now `icon_<key>`.
- `functions/enrich-icon/index.ts` and `src/__workshop__/use-icon-search.ts`: recover the icon key from `_id` with the `icon_` prefix.

No cleanup/migration logic is included — the old partially-seeded `icon.` docs will be handled separately.

Verified with `pnpm lint`, `pnpm knip`, `pnpm build:showcase`, and a full `tsc -p`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27cff548-e355-4b55-8993-6a33d410f9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27cff548-e355-4b55-8993-6a33d410f9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

