### PR TITLE
Improve icon enrichment prompts (no keyword dump, Sanity UI context)

### DIFF
--- a/functions/enrich-icon/index.ts
+++ b/functions/enrich-icon/index.ts
@@ -18,6 +18,14 @@ export const handler = documentEventHandler<IconEvent>(async ({context, event}) 
 
   const label = _id.replace(/^icon_/, '')
 
+  // Shared context so the model understands these are interface glyphs, not
+  // illustrations: they are used on software surfaces like Sanity Studio, Sanity
+  // UI, the Portable Text Editor, and Sanity plugins.
+  const preamble =
+    `This is a monochrome line icon (an interface glyph) named "${label}" from the ` +
+    'Sanity icon set. These icons appear on software surfaces such as Sanity Studio, ' +
+    'Sanity UI, the Portable Text Editor, and Sanity plugins.'
+
   // 1. Use Sanity's native vision model (Agent Actions) to look at the
   //    rasterized icon and write a search-friendly description.
   await client.agent.action.transform({
@@ -26,11 +34,10 @@ export const handler = documentEventHandler<IconEvent>(async ({context, event}) 
     // Write to the published document (not a draft) so dataset embeddings index it.
     forcePublishedWrite: true,
     instruction: [
-      `This is a minimal, monochrome line UI icon named "${label}".`,
-      'Write a short, search-friendly description of what it depicts,',
-      'then list the concepts, actions, objects and synonyms a person might',
-      'type to find it (for example, a clock should mention "time").',
-      'Do not mention colors, the word "icon", or that it is an SVG.',
+      preamble,
+      'In one or two sentences, describe what the glyph depicts and the action or',
+      'concept it represents in such an interface.',
+      'Do not list keywords or synonyms, and do not mention colors or that it is an SVG.',
     ].join(' '),
     target: [
       {
@@ -40,15 +47,17 @@ export const handler = documentEventHandler<IconEvent>(async ({context, event}) 
     ],
   })
 
-  // 2. Derive concise search tags from the description just written.
+  // 2. Derive concise search tags (keywords live here, not in the description).
   await client.agent.action.generate({
     schemaId: '_.schemas.default',
     documentId: _id,
     forcePublishedWrite: true,
     instruction: [
-      'Using the icon description in $description, generate a concise set of',
-      'lowercase search tags: the objects, actions, concepts and common synonyms',
-      'someone might search to find this UI icon. Prefer single words or short phrases.',
+      preamble,
+      'Using the description in $description, generate a concise set of lowercase',
+      'search tags: the objects, actions, concepts, UI features and common synonyms',
+      'someone building or using a Sanity Studio, Portable Text Editor, or Sanity',
+      'plugin might search to find this icon. Prefer single words or short phrases.',
     ].join(' '),
     instructionParams: {
       description: {type: 'field', path: ['description']},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two enrichment fixes in `functions/enrich-icon`:

1. **No duplicated keywords in the description.** The `image-description` prompt was appending a "Keywords: …" list to the description, duplicating what already lives in `tags`. The description prompt now asks for a one-to-two sentence description only ("Do not list keywords or synonyms"); keywords stay in the `tags` field (generated separately).

2. **Sanity software context.** Both the description and tags prompts now share a preamble telling the model these are interface glyphs used on software surfaces — Sanity Studio, Sanity UI, the Portable Text Editor, and Sanity plugins — so descriptions and tags reflect UI/editor usage rather than generic clip-art.

Existing icon docs won't change until re-enriched (drop `description` on the doc, or re-seed, to re-trigger the function).

Verified with `pnpm lint` and `tsc`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27cff548-e355-4b55-8993-6a33d410f9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27cff548-e355-4b55-8993-6a33d410f9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

