### PR TITLE
feat!: drop CommonJS support, require Node.js <=22.12

### DIFF
--- a/.changeset/drop-commonjs-support.md
+++ b/.changeset/drop-commonjs-support.md
@@ -1,0 +1,7 @@
+---
+"@sanity/icons": major
+---
+
+Drop CommonJS support and require Node.js `>=22.12`
+
+`@sanity/icons` is now ESM-only. The `require` export condition and the CommonJS build output (`./dist/index.cjs`) have been removed, so the package must be consumed via ESM `import`. The minimum supported Node.js version has been raised to `>=22.12` to match `sanity`.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@sanity/icons": "3.7.7"
+  },
+  "changesets": []
+}

--- a/package.json
+++ b/package.json
@@ -22,13 +22,12 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
@@ -36,7 +35,6 @@
   "publishConfig": {
     "exports": {
       ".": {
-        "require": "./dist/index.cjs",
         "default": "./dist/index.js"
       },
       "./package.json": "./package.json"
@@ -118,7 +116,7 @@
     }
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=22.12"
   },
   "packageManager": "pnpm@11.9.0",
   "esm.sh": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `@sanity/icons` **ESM-only** as a breaking change, and raises the minimum Node.js version to match `sanity`.

- Remove the `require` export condition from both `exports` and `publishConfig.exports`.
- Drop the CommonJS `./dist/index.cjs` build output; `pkg build` now emits ESM only.
- Point `main` at the ESM entry (`./dist/index.js`) instead of the removed `.cjs` file.
- Bump `engines.node` from `>=14.0.0` to `>=22.12` (matches `sanity`).
- Add a **major** changeset describing the breaking change.
- Enable changesets **prerelease mode** with the `rc` tag (`.changeset/pre.json`), so the next release publishes as e.g. `4.0.0-rc.0`.

> Note on the prerelease tag: `rc` was chosen since no tag was specified. To switch, run `pnpm changeset pre exit` then `pnpm changeset pre enter <tag>`.

## Testing

- `pnpm exec pkg build --strict --clean --check` — builds ESM-only (`format: esm`), emits only `dist/index.js` + `dist/index.d.ts` (no `.cjs`), passes strict checks.
- `pnpm lint` — passes.
- `pnpm test` — passes.
- `pnpm exec changeset status --verbose` — reports `@sanity/icons 4.0.0-rc.0` (major bump, prerelease `rc`).
- ESM self-reference import in Node `v22.14.0`: `import * as icons from '@sanity/icons'` resolves via the `exports` map and exposes 238 named exports.

CI's test matrix already runs Node `lts`/`latest` (both ≥ 22.12), so the engine bump is compatible without workflow changes.

BREAKING CHANGE: `@sanity/icons` no longer ships a CommonJS build and requires Node.js `>=22.12`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e52d3b1-c666-498e-aa45-2a8d2d38dbf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e52d3b1-c666-498e-aa45-2a8d2d38dbf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

