### PR TITLE
chore: remove unused esm.sh bundle config

### DIFF
--- a/.changeset/remove-esm-sh-bundle-config.md
+++ b/.changeset/remove-esm-sh-bundle-config.md
@@ -1,0 +1,5 @@
+---
+"@sanity/icons": patch
+---
+
+Remove the unused `esm.sh` bundling override from `package.json`. It was added back when the package still shipped a CommonJS build; now that `@sanity/icons` is ESM-only with a single bundled entry point, esm.sh's default bundling behaviour has nothing extra to bundle, so the override is no longer needed.

--- a/package.json
+++ b/package.json
@@ -118,8 +118,5 @@
   "engines": {
     "node": ">=22.12"
   },
-  "packageManager": "pnpm@11.9.0",
-  "esm.sh": {
-    "bundle": false
-  }
+  "packageManager": "pnpm@11.9.0"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Removes the `"esm.sh": { "bundle": false }` field from `package.json`.

This override was added in [ce00433](https://github.com/sanity-io/icons/commit/ce00433d0feb756e622c972875f8c37c04bd3a88) (2024) to opt `@sanity/icons` out of esm.sh's default sub-module bundling, as part of a broader effort across `@sanity/*` packages to avoid singleton/context duplication when Studio loaded dependencies via esm.sh-based import maps.

Now that `@sanity/icons` is ESM-only (#200) with a single self-contained bundled entry point (`dist/index.js`, no internal sub-module imports), esm.sh's default bundling behavior has nothing extra to bundle for this package, so the override is no longer needed.

### What to review

- `package.json`: field removal.
- `.changeset/remove-esm-sh-bundle-config.md`: patch changeset describing the change.

### Testing

- `pnpm lint`, `pnpm test`, and `pnpm build` all pass.
- `pnpm knip` shows only the pre-existing, unrelated `lefthook` warning (verified present on `main` too).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecfcd5e4-ccc0-469e-a57c-84073790b37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecfcd5e4-ccc0-469e-a57c-84073790b37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

