### PR TITLE
Add compact grid view to icon showcase

### DIFF
--- a/src/__workshop__/grid-view.tsx
+++ b/src/__workshop__/grid-view.tsx
@@ -11,22 +11,22 @@ const COPY_FEEDBACK_DURATION = 1500
 
 const TILE_SIZE = '72px'
 
-// Fixed-size (not `minmax(..., 1fr)`) columns: growing tracks would require
-// `aspect-ratio` on the tile to keep it square, and WebKit fails to
-// recompute row heights for `aspect-ratio` grid children after the viewport
-// is resized (reproduced with Playwright: correct on fresh load, rows
-// collapse together after a live resize). Fixed columns need no
-// aspect-ratio, sidestepping the bug; any leftover space per row is simply
-// left blank, which is standard for icon-grid layouts.
-const GRID_STYLE = {
-  gridTemplateColumns: `repeat(auto-fill, ${TILE_SIZE})`,
-  justifyContent: 'space-between',
-}
+// Columns flex to fill the row (`1fr`), so tiles stretch to close any
+// leftover width instead of leaving a gap on the right edge, while `gap`
+// stays the single source of truth for spacing between both rows and
+// columns. The tile's *height* is a fixed px value rather than derived from
+// its (now variable) width via `aspect-ratio` — WebKit fails to recompute
+// an aspect-ratio-derived row height after the viewport is resized
+// (reproduced with Playwright: correct on fresh load, rows collapse
+// together after a live resize). Since height never depends on width here,
+// that recomputation never has to happen, sidestepping the bug. Tiles are
+// no longer perfectly square when a row stretches, but the icon inside
+// stays a fixed size and just gains more horizontal breathing room.
+const GRID_STYLE = {gridTemplateColumns: `repeat(auto-fill, minmax(${TILE_SIZE}, 1fr))`}
 
 // `Card`'s `border` prop has no effect when `as="button"` (its button-reset
 // CSS sets `border: 0`), so the border is drawn via inline style instead.
 const TILE_STYLE = {
-  width: TILE_SIZE,
   height: TILE_SIZE,
   border: '1px solid var(--card-border-color)',
   display: 'flex',

--- a/src/__workshop__/grid-view.tsx
+++ b/src/__workshop__/grid-view.tsx
@@ -17,7 +17,7 @@ const TILE_STYLE = {aspectRatio: '1', border: '1px solid var(--card-border-color
 
 // `lineHeight: 0` collapses the icon's inline line box so its baseline
 // whitespace doesn't push it off-center within the flex-centered tile.
-const ICON_STYLE = {fontSize: '20px', lineHeight: 0}
+const ICON_STYLE = {fontSize: '26px', lineHeight: 0}
 
 type CopyState = 'idle' | 'copied' | 'error'
 
@@ -65,7 +65,7 @@ function GridIconTile({icon}: {icon: string}) {
         aria-label={`Copy import for ${icon}`}
         as="button"
         onClick={handleCopy}
-        padding={2}
+        padding={1}
         radius={2}
         style={TILE_STYLE}
         tone={tone}

--- a/src/__workshop__/grid-view.tsx
+++ b/src/__workshop__/grid-view.tsx
@@ -18,7 +18,10 @@ const TILE_SIZE = '72px'
 // collapse together after a live resize). Fixed columns need no
 // aspect-ratio, sidestepping the bug; any leftover space per row is simply
 // left blank, which is standard for icon-grid layouts.
-const GRID_STYLE = {gridTemplateColumns: `repeat(auto-fill, ${TILE_SIZE})`}
+const GRID_STYLE = {
+  gridTemplateColumns: `repeat(auto-fill, ${TILE_SIZE})`,
+  justifyContent: 'space-between',
+}
 
 // `Card`'s `border` prop has no effect when `as="button"` (its button-reset
 // CSS sets `border: 0`), so the border is drawn via inline style instead.

--- a/src/__workshop__/grid-view.tsx
+++ b/src/__workshop__/grid-view.tsx
@@ -1,7 +1,7 @@
 import {Icon, type IconSymbol} from '@sanity/icons'
 import {CheckmarkIcon} from '@sanity/icons/Checkmark'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Card, Flex, Grid, Text, Tooltip} from '@sanity/ui'
+import {Card, Grid, Text, Tooltip} from '@sanity/ui'
 import copy from 'copy-to-clipboard'
 import {useEffect, useState} from 'react'
 
@@ -9,15 +9,25 @@ import {getImportCode} from './icon-code'
 
 const COPY_FEEDBACK_DURATION = 1500
 
-const GRID_STYLE = {gridTemplateColumns: 'repeat(auto-fill, minmax(56px, 1fr))'}
+const GRID_STYLE = {gridTemplateColumns: 'repeat(auto-fill, minmax(72px, 1fr))'}
 
 // `Card`'s `border` prop has no effect when `as="button"` (its button-reset
 // CSS sets `border: 0`), so the border is drawn via inline style instead.
-const TILE_STYLE = {aspectRatio: '1', border: '1px solid var(--card-border-color)'}
+// Centering is done here (rather than a nested `<Flex height="fill">`)
+// because in WebKit a percentage-height flex child of an aspect-ratio box
+// resolves against the border box, overflowing past the bottom padding and
+// pushing its content down.
+const TILE_STYLE = {
+  aspectRatio: '1',
+  border: '1px solid var(--card-border-color)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
 
 // `lineHeight: 0` collapses the icon's inline line box so its baseline
-// whitespace doesn't push it off-center within the flex-centered tile.
-const ICON_STYLE = {fontSize: '26px', lineHeight: 0}
+// whitespace doesn't push it off-center. Sized to match the icon in list view.
+const ICON_STYLE = {fontSize: '33px', lineHeight: 0}
 
 type CopyState = 'idle' | 'copied' | 'error'
 
@@ -70,9 +80,7 @@ function GridIconTile({icon}: {icon: string}) {
         style={TILE_STYLE}
         tone={tone}
       >
-        <Flex align="center" height="fill" justify="center" style={ICON_STYLE}>
-          {iconElement}
-        </Flex>
+        <span style={ICON_STYLE}>{iconElement}</span>
       </Card>
     </Tooltip>
   )

--- a/src/__workshop__/grid-view.tsx
+++ b/src/__workshop__/grid-view.tsx
@@ -9,15 +9,21 @@ import {getImportCode} from './icon-code'
 
 const COPY_FEEDBACK_DURATION = 1500
 
-const GRID_TEMPLATE_COLUMNS = [3, 4, 6, 8]
+const GRID_STYLE = {gridTemplateColumns: 'repeat(auto-fill, minmax(56px, 1fr))'}
 
-const TILE_STYLE = {aspectRatio: '1'}
+// `Card`'s `border` prop has no effect when `as="button"` (its button-reset
+// CSS sets `border: 0`), so the border is drawn via inline style instead.
+const TILE_STYLE = {aspectRatio: '1', border: '1px solid var(--card-border-color)'}
+
+// `lineHeight: 0` collapses the icon's inline line box so its baseline
+// whitespace doesn't push it off-center within the flex-centered tile.
+const ICON_STYLE = {fontSize: '20px', lineHeight: 0}
 
 type CopyState = 'idle' | 'copied' | 'error'
 
 export function GridView({iconKeys}: {iconKeys: string[]}) {
   return (
-    <Grid gap={2} gridTemplateColumns={GRID_TEMPLATE_COLUMNS}>
+    <Grid gap={2} style={GRID_STYLE}>
       {iconKeys.map((key) => (
         <GridIconTile key={key} icon={key} />
       ))}
@@ -58,15 +64,14 @@ function GridIconTile({icon}: {icon: string}) {
         __unstable_focusRing
         aria-label={`Copy import for ${icon}`}
         as="button"
-        border
         onClick={handleCopy}
-        padding={3}
+        padding={2}
         radius={2}
         style={TILE_STYLE}
         tone={tone}
       >
-        <Flex align="center" height="fill" justify="center">
-          <Text size={4}>{iconElement}</Text>
+        <Flex align="center" height="fill" justify="center" style={ICON_STYLE}>
+          {iconElement}
         </Flex>
       </Card>
     </Tooltip>

--- a/src/__workshop__/grid-view.tsx
+++ b/src/__workshop__/grid-view.tsx
@@ -1,0 +1,82 @@
+import {Icon, type IconSymbol} from '@sanity/icons'
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
+import {Card, Flex, Grid, Text, Tooltip} from '@sanity/ui'
+import copy from 'copy-to-clipboard'
+import {useEffect, useState} from 'react'
+
+import {getImportCode} from './icon-code'
+
+const COPY_FEEDBACK_DURATION = 1500
+
+const GRID_TEMPLATE_COLUMNS = [3, 4, 6, 8]
+
+const TILE_STYLE = {aspectRatio: '1'}
+
+type CopyState = 'idle' | 'copied' | 'error'
+
+export function GridView({iconKeys}: {iconKeys: string[]}) {
+  return (
+    <Grid gap={2} gridTemplateColumns={GRID_TEMPLATE_COLUMNS}>
+      {iconKeys.map((key) => (
+        <GridIconTile key={key} icon={key} />
+      ))}
+    </Grid>
+  )
+}
+
+function GridIconTile({icon}: {icon: string}) {
+  const [state, setState] = useState<CopyState>('idle')
+
+  useEffect(() => {
+    if (state === 'idle') return undefined
+
+    const timeout = setTimeout(() => setState('idle'), COPY_FEEDBACK_DURATION)
+    return () => clearTimeout(timeout)
+  }, [state])
+
+  function handleCopy() {
+    copy(getImportCode(icon)).then(
+      (ok) => setState(ok ? 'copied' : 'error'),
+      () => setState('error'),
+    )
+  }
+
+  const tone = state === 'copied' ? 'positive' : state === 'error' ? 'critical' : 'default'
+  const iconElement =
+    state === 'copied' ? (
+      <CheckmarkIcon />
+    ) : state === 'error' ? (
+      <ErrorOutlineIcon />
+    ) : (
+      <Icon symbol={icon as IconSymbol} />
+    )
+
+  return (
+    <Tooltip content={<TooltipLabel>{icon}</TooltipLabel>} placement="top" portal>
+      <Card
+        __unstable_focusRing
+        aria-label={`Copy import for ${icon}`}
+        as="button"
+        border
+        onClick={handleCopy}
+        padding={3}
+        radius={2}
+        style={TILE_STYLE}
+        tone={tone}
+      >
+        <Flex align="center" height="fill" justify="center">
+          <Text size={4}>{iconElement}</Text>
+        </Flex>
+      </Card>
+    </Tooltip>
+  )
+}
+
+function TooltipLabel({children}: {children: React.ReactNode}) {
+  return (
+    <Card padding={2} radius={2} tone="default">
+      <Text size={1}>{children}</Text>
+    </Card>
+  )
+}

--- a/src/__workshop__/grid-view.tsx
+++ b/src/__workshop__/grid-view.tsx
@@ -9,16 +9,22 @@ import {getImportCode} from './icon-code'
 
 const COPY_FEEDBACK_DURATION = 1500
 
-const GRID_STYLE = {gridTemplateColumns: 'repeat(auto-fill, minmax(72px, 1fr))'}
+const TILE_SIZE = '72px'
+
+// Fixed-size (not `minmax(..., 1fr)`) columns: growing tracks would require
+// `aspect-ratio` on the tile to keep it square, and WebKit fails to
+// recompute row heights for `aspect-ratio` grid children after the viewport
+// is resized (reproduced with Playwright: correct on fresh load, rows
+// collapse together after a live resize). Fixed columns need no
+// aspect-ratio, sidestepping the bug; any leftover space per row is simply
+// left blank, which is standard for icon-grid layouts.
+const GRID_STYLE = {gridTemplateColumns: `repeat(auto-fill, ${TILE_SIZE})`}
 
 // `Card`'s `border` prop has no effect when `as="button"` (its button-reset
 // CSS sets `border: 0`), so the border is drawn via inline style instead.
-// Centering is done here (rather than a nested `<Flex height="fill">`)
-// because in WebKit a percentage-height flex child of an aspect-ratio box
-// resolves against the border box, overflowing past the bottom padding and
-// pushing its content down.
 const TILE_STYLE = {
-  aspectRatio: '1',
+  width: TILE_SIZE,
+  height: TILE_SIZE,
   border: '1px solid var(--card-border-color)',
   display: 'flex',
   alignItems: 'center',

--- a/src/__workshop__/icon-code.ts
+++ b/src/__workshop__/icon-code.ts
@@ -1,0 +1,15 @@
+function ucfirst(str: string) {
+  return str.slice(0, 1).toUpperCase() + str.slice(1)
+}
+
+export function toPascalCase(str: string) {
+  const p = str.split('-')
+
+  return p.map(ucfirst).join('')
+}
+
+export function getImportCode(icon: string): string {
+  const pascalCase = toPascalCase(icon)
+
+  return `import {${pascalCase}Icon} from '@sanity/icons/${pascalCase}'`
+}

--- a/src/__workshop__/overview.tsx
+++ b/src/__workshop__/overview.tsx
@@ -5,6 +5,8 @@ import {CopyIcon} from '@sanity/icons/Copy'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {SearchIcon} from '@sanity/icons/Search'
 import {SpinnerIcon} from '@sanity/icons/Spinner'
+import {ThLargeIcon} from '@sanity/icons/ThLarge'
+import {ThListIcon} from '@sanity/icons/ThList'
 import {
   Box,
   Button,
@@ -24,6 +26,8 @@ import {registerLanguage} from 'react-refractor'
 import tsx from 'refractor/typescript'
 import {keyframes, styled} from 'styled-components'
 
+import {GridView} from './grid-view'
+import {getImportCode} from './icon-code'
 import {useIconSearch} from './use-icon-search'
 
 registerLanguage(tsx)
@@ -45,14 +49,34 @@ const COPY_FEEDBACK_DURATION = 1500
 
 type CopyState = 'idle' | 'copied' | 'error'
 
-function ucfirst(str: string) {
-  return str.slice(0, 1).toUpperCase() + str.slice(1)
-}
+type ViewMode = 'list' | 'grid'
 
-function toPascalCase(str: string) {
-  const p = str.split('-')
-
-  return p.map(ucfirst).join('')
+function ViewToggle({view, onChange}: {view: ViewMode; onChange: (view: ViewMode) => void}) {
+  return (
+    <Card border overflow="hidden" radius={2}>
+      <Flex>
+        <Button
+          aria-label="List view"
+          icon={ThListIcon}
+          mode="bleed"
+          onClick={() => onChange('list')}
+          padding={3}
+          radius={0}
+          selected={view === 'list'}
+        />
+        <Card borderLeft />
+        <Button
+          aria-label="Grid view"
+          icon={ThLargeIcon}
+          mode="bleed"
+          onClick={() => onChange('grid')}
+          padding={3}
+          radius={0}
+          selected={view === 'grid'}
+        />
+      </Flex>
+    </Card>
+  )
 }
 
 function CopyCodeButton({code}: {code: string}) {
@@ -118,6 +142,10 @@ export default function OverviewStory() {
     const searchParams = new URLSearchParams(window.location.search)
     return searchParams.get('query') ?? ''
   })
+  const [view, setView] = useState<ViewMode>(() => {
+    const searchParams = new URLSearchParams(window.location.search)
+    return searchParams.get('view') === 'grid' ? 'grid' : 'list'
+  })
   const {results: iconKeys, loading} = useIconSearch(query)
 
   useEffect(() => {
@@ -125,43 +153,49 @@ export default function OverviewStory() {
       const id = requestIdleCallback(() => {
         const searchParams = new URLSearchParams(window.location.search)
         searchParams.set('query', query)
+        searchParams.set('view', view)
         window.history.replaceState(null, '', `?${searchParams}`)
       })
       return () => cancelIdleCallback(id)
     }
     return undefined
-  }, [query])
+  }, [query, view])
 
   return (
     <Card padding={[4, 5, 6]}>
       <Container width={1}>
-        <Box marginBottom={4}>
-          <TextInput
-            icon={loading ? <SpinningIcon /> : SearchIcon}
-            onChange={(event) => startTransition(() => setQuery(event.currentTarget.value))}
-            placeholder="Fuzzy search icons by name or meaning, e.g. “oh no” or “delete”…"
-            radius={2}
-            defaultValue={query}
-          />
-        </Box>
+        <Flex gap={2} marginBottom={4}>
+          <Box flex={1}>
+            <TextInput
+              icon={loading ? <SpinningIcon /> : SearchIcon}
+              onChange={(event) => startTransition(() => setQuery(event.currentTarget.value))}
+              placeholder="Fuzzy search icons by name or meaning, e.g. “oh no” or “delete”…"
+              radius={2}
+              defaultValue={query}
+            />
+          </Box>
+          <ViewToggle onChange={setView} view={view} />
+        </Flex>
 
         {iconKeys.length === 0 && !loading && <Text>No matches</Text>}
 
-        {iconKeys.length > 0 && (
-          <Stack gap={3}>
-            {iconKeys.map((key) => (
-              <CodeSnippet key={key} icon={key} />
-            ))}
-          </Stack>
-        )}
+        {iconKeys.length > 0 &&
+          (view === 'grid' ? (
+            <GridView iconKeys={iconKeys} />
+          ) : (
+            <Stack gap={3}>
+              {iconKeys.map((key) => (
+                <CodeSnippet key={key} icon={key} />
+              ))}
+            </Stack>
+          ))}
       </Container>
     </Card>
   )
 }
 
 function CodeSnippet({icon}: {icon: string}) {
-  const pascalCase = toPascalCase(icon)
-  const code = `import {${pascalCase}Icon} from '@sanity/icons/${pascalCase}'`
+  const code = getImportCode(icon)
 
   return (
     <Card border overflow="hidden" radius={2}>


### PR DESCRIPTION
## Summary
- Adds a denser grid view alongside the existing list view on the icon showcase, toggled via connected list/grid buttons next to the search box (using the icon library's own `ThListIcon`/`ThLargeIcon`).
- Grid tiles show just the SVG glyph, a tooltip with the icon's name on hover, and copy the icon's import snippet to the clipboard on click (with checkmark/error feedback).
- Search continues to filter both views identically — the toggle and view state are query-string synced (`?view=`) alongside the existing `?query=`.

## Notes
Most of the follow-up commits fix real cross-browser layout bugs found during review (verified with Playwright in both Chromium and WebKit):
- `Card`'s `border` prop is a no-op when rendered `as="button"` (its own reset CSS sets `border: 0`) — drawn via inline style instead.
- WebKit fails to recompute a percentage-height flex child's height inside a padded `aspect-ratio` box, and separately fails to recompute `aspect-ratio`-derived row heights in a CSS Grid after a live viewport resize (both reproduced and confirmed fixed via automated Playwright resize sequences). Centering and sizing were reworked to avoid `aspect-ratio` and percentage heights entirely.
- Grid columns are flexible (`minmax(72px, 1fr)`) so tiles stretch to fill the row width with a single consistent gap value on both axes, instead of leaving blank space on the right edge at in-between viewport widths.

## Test plan
- [x] `pnpm lint` / `tsc --noEmit` / `pnpm test` all pass
- [x] Manually verified in Chromium and WebKit: search filters both views identically, tooltip + click-to-copy work, grid gap/centering hold across a resize sweep from 320px–1280px
- [ ] Visual review from a maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)